### PR TITLE
Implement right comodules over corings

### DIFF
--- a/examples.ts
+++ b/examples.ts
@@ -36,7 +36,9 @@ import {
   // Advanced evaluators
   evalExprNum2, evalExprR, evalExprRR, showExprMinParens2,
   // Monoids
-  MonoidArray
+  MonoidArray,
+  // Categorical theory
+  SemiringNat, makeDiagonalCoring, makeDiagonalComodule, comoduleCoassocHolds, comoduleCounitHolds
 } from './allTS'
 
 // ====================================================================
@@ -536,6 +538,37 @@ namespace SafeASTEvolutionExamples {
 }
 
 // ====================================================================
+// 8. CATEGORICAL THEORY - Comodules over Corings
+// ====================================================================
+
+namespace ComoduleExamples {
+  export function runAll() {
+    console.log('\n--- Comodule Examples ---')
+    
+    // Create a diagonal coring on R^3
+    const C = makeDiagonalCoring(SemiringNat)(3)
+    console.log('Diagonal coring C on R^3 created')
+    
+    // Create a diagonal comodule M ≅ R^2 with ρ(e0)=e0⊗c0, ρ(e1)=e1⊗c1
+    const M = makeDiagonalComodule(C)(2, k => k % 3)
+    console.log('Diagonal comodule M ≅ R^2 created with tagging function k ↦ k mod 3')
+    
+    // Check coaction laws
+    const coassocHolds = comoduleCoassocHolds(M)
+    const counitHolds = comoduleCounitHolds(M)
+    
+    console.log(`Coassociativity law holds: ${coassocHolds}`)
+    console.log(`Counit law holds: ${counitHolds}`)
+    
+    if (coassocHolds && counitHolds) {
+      console.log('✓ M is a lawful right C-comodule!')
+    } else {
+      console.log('✗ M violates comodule laws')
+    }
+  }
+}
+
+// ====================================================================
 // RUNNER - Uncomment examples to test them
 // ====================================================================
 
@@ -561,6 +594,7 @@ async function runExamples() {
   // JsonStreamingExamples
   // FusedPipelineExamples
   // SafeASTEvolutionExamples
+  ComoduleExamples.runAll()
   
   console.log('Examples ready to run! Uncomment the ones you want to test.')
 }
@@ -582,7 +616,8 @@ export type {
   SequenceExamples,
   JsonStreamingExamples,
   FusedPipelineExamples,
-  SafeASTEvolutionExamples
+  SafeASTEvolutionExamples,
+  ComoduleExamples
 }
 
 // Run if this file is executed directly

--- a/test/comodule.spec.ts
+++ b/test/comodule.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SemiringNat,
+  makeDiagonalCoring,
+  makeDiagonalComodule,
+  comoduleCoassocHolds,
+  comoduleCounitHolds,
+} from '../allTS'
+
+describe('Right comodules over diagonal coring', () => {
+  it('diagonal coaction satisfies laws', () => {
+    const C = makeDiagonalCoring(SemiringNat)(4)
+    const M = makeDiagonalComodule(C)(3, k => k) // tag i ↦ i
+    expect(comoduleCoassocHolds(M)).toBe(true)
+    expect(comoduleCounitHolds(M)).toBe(true)
+  })
+
+  it('diagonal coaction with modular tagging satisfies laws', () => {
+    const C = makeDiagonalCoring(SemiringNat)(3)
+    const M = makeDiagonalComodule(C)(2, k => k % 3) // tag with modulo
+    expect(comoduleCoassocHolds(M)).toBe(true)
+    expect(comoduleCounitHolds(M)).toBe(true)
+  })
+
+  it('works with larger dimensions', () => {
+    const C = makeDiagonalCoring(SemiringNat)(5)
+    const M = makeDiagonalComodule(C)(4, k => (k * 2) % 5) // more complex tagging
+    expect(comoduleCoassocHolds(M)).toBe(true)
+    expect(comoduleCounitHolds(M)).toBe(true)
+  })
+})


### PR DESCRIPTION
Add balanced tensor of maps, bicomodules, and object-level tensor product to advance towards a bicategory of corings.

---
<a href="https://cursor.com/background-agent?bcId=bc-61158270-0568-49ca-91e9-1b8bb926e39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61158270-0568-49ca-91e9-1b8bb926e39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

