### PR TITLE
Add Kolmogorov and Hewitt–Savage zero-one law oracles

### DIFF
--- a/algebra-oracles.ts
+++ b/algebra-oracles.ts
@@ -1,0 +1,55 @@
+// Registry for algebra-specific oracles following the semicartesian development
+
+import type { CRingPlusObj, CRingPlusMor } from "./cring-plus";
+import {
+  checkCRingPlusInitialSemicartesian,
+  buildCRingPlusCausalityScenario,
+  checkCRingPlusCausalityCounterexample,
+} from "./cring-plus";
+import {
+  checkComplexCStarAxioms,
+  checkComplexIdentityHomomorphism,
+  checkComplexSpectralTheory,
+} from "./cstar-algebra";
+import type { InitialArrowSample } from "./semicartesian-structure";
+
+export const AlgebraOracles = {
+  semicartesian: {
+    cringPlusInitialUnit: checkCRingPlusInitialSemicartesian,
+  },
+  causality: {
+    counterexampleScenario: buildCRingPlusCausalityScenario,
+    counterexampleOracle: checkCRingPlusCausalityCounterexample,
+  },
+  cstar: {
+    complexAxioms: checkComplexCStarAxioms,
+    identityHom: checkComplexIdentityHomomorphism,
+    spectral: checkComplexSpectralTheory,
+  },
+} as const;
+
+export const checkAllAlgebraLaws = (
+  targets: ReadonlyArray<CRingPlusObj>,
+  samples: ReadonlyArray<InitialArrowSample<CRingPlusObj, CRingPlusMor>> = []
+): {
+  semicartesian: boolean;
+  details: string;
+  causality: ReturnType<typeof checkCRingPlusCausalityCounterexample>;
+  cstar: {
+    axioms: ReturnType<typeof checkComplexCStarAxioms>;
+    identityHom: ReturnType<typeof checkComplexIdentityHomomorphism>;
+    spectral: ReturnType<typeof checkComplexSpectralTheory>;
+  };
+} => {
+  const result = checkCRingPlusInitialSemicartesian(targets, samples);
+  const causality = checkCRingPlusCausalityCounterexample();
+  const axioms = checkComplexCStarAxioms();
+  const identityHom = checkComplexIdentityHomomorphism();
+  const spectral = checkComplexSpectralTheory();
+  return {
+    semicartesian: result.holds,
+    details: result.details,
+    causality,
+    cstar: { axioms, identityHom, spectral },
+  };
+};

--- a/cring-plus-filtered-tensor.ts
+++ b/cring-plus-filtered-tensor.ts
@@ -1,0 +1,382 @@
+// 🔮 BEGIN_MATH: CRingPlusFilteredTensorColimit
+// 📝 Brief: Model infinite tensor products in CRing_⊕ as filtered colimits of finite tensor products.
+// 🏗️ Domain: Algebra / symmetric monoidal categories
+// 🔗 Integration: Supplies executable colimit witnesses for Example 3.4 and exposes additive/multiplicative structure.
+// 📋 Plan:
+//   1. Represent elementary tensors with finite support and normalize formal sums canonically.
+//   2. Implement addition, negation, and multiplication on formal sums using CRing_⊕ ring data.
+//   3. Provide filtered-diagram helpers (inclusions, restrictions, support) with compatibility oracles.
+
+import type { CRingPlusObject } from "./cring-plus";
+
+export type FiniteSubset<J> = ReadonlyArray<J>;
+
+export interface TensorComponent<J, A> {
+  readonly index: J;
+  readonly object: CRingPlusObject<A>;
+}
+
+export interface TensorFamily<J, A> {
+  readonly components: ReadonlyArray<TensorComponent<J, A>>;
+  readonly eqIndex: (a: J, b: J) => boolean;
+  readonly describeIndex?: (index: J) => string;
+}
+
+interface NormalEntry<J, A> {
+  readonly index: J;
+  readonly key: string;
+  readonly value: A;
+}
+
+interface NormalTerm<J, A> {
+  readonly coefficient: bigint;
+  readonly entries: ReadonlyArray<NormalEntry<J, A>>;
+}
+
+export interface TensorElement<J, A> {
+  readonly terms: ReadonlyArray<NormalTerm<J, A>>;
+}
+
+const keyOf = <J, A>(family: TensorFamily<J, A>, index: J): string =>
+  family.describeIndex?.(index) ?? String(index);
+
+const getComponent = <J, A>(family: TensorFamily<J, A>, index: J): TensorComponent<J, A> => {
+  const component = family.components.find(({ index: candidate }) => family.eqIndex(candidate, index));
+  if (!component) {
+    throw new Error(`Missing tensor component for index ${String(index)}`);
+  }
+  return component;
+};
+
+const describeValue = <J, A>(family: TensorFamily<J, A>, index: J, value: A): string => {
+  const component = getComponent(family, index);
+  return component.object.format?.(value) ?? String(value);
+};
+
+const normalizeEntries = <J, A>(
+  family: TensorFamily<J, A>,
+  entries: ReadonlyArray<{ index: J; value: A }>,
+): ReadonlyArray<NormalEntry<J, A>> => {
+  const combined = new Map<string, { index: J; value: A }>();
+
+  for (const entry of entries) {
+    const key = keyOf(family, entry.index);
+    const { object } = getComponent(family, entry.index);
+    const current = combined.get(key);
+    const nextValue = current
+      ? object.ring.mul(current.value, entry.value)
+      : entry.value;
+
+    if (object.ring.eq(nextValue, object.ring.one)) {
+      combined.delete(key);
+    } else {
+      combined.set(key, { index: entry.index, value: nextValue });
+    }
+  }
+
+  const normalized: NormalEntry<J, A>[] = [];
+  combined.forEach(({ index, value }, key) => {
+    normalized.push({ index, key, value });
+  });
+  normalized.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return normalized;
+};
+
+const mergeTerms = <J, A>(
+  family: TensorFamily<J, A>,
+  terms: ReadonlyArray<NormalTerm<J, A>>,
+): ReadonlyArray<NormalTerm<J, A>> => {
+  const byKey = new Map<string, NormalTerm<J, A>>();
+
+  for (const term of terms) {
+    if (term.coefficient === 0n) continue;
+    const descriptor = term.entries
+      .map((entry) => `${entry.key}:${describeValue(family, entry.index, entry.value)}`)
+      .join("|");
+    const existing = byKey.get(descriptor);
+    if (existing) {
+      const coeff = existing.coefficient + term.coefficient;
+      if (coeff === 0n) {
+        byKey.delete(descriptor);
+      } else {
+        byKey.set(descriptor, { coefficient: coeff, entries: existing.entries });
+      }
+    } else {
+      byKey.set(descriptor, term);
+    }
+  }
+
+  return Array.from(byKey.values()).sort((a, b) => {
+    const aKey = a.entries.map((entry) => entry.key).join("|");
+    const bKey = b.entries.map((entry) => entry.key).join("|");
+    if (aKey < bKey) return -1;
+    if (aKey > bKey) return 1;
+    return Number(a.coefficient - b.coefficient);
+  });
+};
+
+const normalizeElement = <J, A>(
+  family: TensorFamily<J, A>,
+  terms: ReadonlyArray<{ coefficient: bigint; entries: ReadonlyArray<{ index: J; value: A }> }>,
+): TensorElement<J, A> => {
+  const normalizedTerms = terms.map((term) => ({
+    coefficient: term.coefficient,
+    entries: normalizeEntries(family, term.entries),
+  }));
+  return { terms: mergeTerms(family, normalizedTerms) };
+};
+
+export const zeroTensor = <J, A>(family: TensorFamily<J, A>): TensorElement<J, A> =>
+  normalizeElement(family, []);
+
+export const unitTensor = <J, A>(family: TensorFamily<J, A>): TensorElement<J, A> =>
+  normalizeElement(family, [{ coefficient: 1n, entries: [] }]);
+
+export const elementaryTensor = <J, A>(
+  family: TensorFamily<J, A>,
+  entries: ReadonlyArray<{ index: J; value: A }>,
+  coefficient: bigint = 1n,
+): TensorElement<J, A> => normalizeElement(family, [{ coefficient, entries }]);
+
+export const addTensors = <J, A>(
+  family: TensorFamily<J, A>,
+  left: TensorElement<J, A>,
+  right: TensorElement<J, A>,
+): TensorElement<J, A> =>
+  normalizeElement(
+    family,
+    [...left.terms, ...right.terms].map((term) => ({
+      coefficient: term.coefficient,
+      entries: term.entries.map(({ index, value }) => ({ index, value })),
+    })),
+  );
+
+export const negateTensor = <J, A>(
+  family: TensorFamily<J, A>,
+  tensor: TensorElement<J, A>,
+): TensorElement<J, A> =>
+  normalizeElement(
+    family,
+    tensor.terms.map((term) => ({
+      coefficient: -term.coefficient,
+      entries: term.entries.map(({ index, value }) => ({ index, value })),
+    })),
+  );
+
+const multiplyEntries = <J, A>(
+  family: TensorFamily<J, A>,
+  left: ReadonlyArray<NormalEntry<J, A>>,
+  right: ReadonlyArray<NormalEntry<J, A>>,
+): ReadonlyArray<NormalEntry<J, A>> => {
+  const combined = new Map<string, { index: J; value: A }>();
+
+  for (const entry of left) {
+    combined.set(entry.key, { index: entry.index, value: entry.value });
+  }
+
+  for (const entry of right) {
+    const existing = combined.get(entry.key);
+    const { object } = getComponent(family, entry.index);
+    const nextValue = existing
+      ? object.ring.mul(existing.value, entry.value)
+      : entry.value;
+
+    if (object.ring.eq(nextValue, object.ring.one)) {
+      combined.delete(entry.key);
+    } else {
+      combined.set(entry.key, { index: entry.index, value: nextValue });
+    }
+  }
+
+  const normalized: NormalEntry<J, A>[] = [];
+  combined.forEach(({ index, value }, key) => {
+    normalized.push({ index, key, value });
+  });
+  normalized.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return normalized;
+};
+
+export const multiplyTensors = <J, A>(
+  family: TensorFamily<J, A>,
+  left: TensorElement<J, A>,
+  right: TensorElement<J, A>,
+): TensorElement<J, A> => {
+  const terms: Array<{ coefficient: bigint; entries: ReadonlyArray<{ index: J; value: A }> }> = [];
+  for (const lTerm of left.terms) {
+    for (const rTerm of right.terms) {
+      const coefficient = lTerm.coefficient * rTerm.coefficient;
+      const entries = multiplyEntries(family, lTerm.entries, rTerm.entries).map(({ index, value }) => ({ index, value }));
+      terms.push({ coefficient, entries });
+    }
+  }
+  return normalizeElement(family, terms);
+};
+
+export const tensorSupport = <J, A>(family: TensorFamily<J, A>, tensor: TensorElement<J, A>): FiniteSubset<J> => {
+  const indices = new Map<string, J>();
+  for (const term of tensor.terms) {
+    for (const entry of term.entries) {
+      indices.set(entry.key, entry.index);
+    }
+  }
+  return Array.from(indices.values());
+};
+
+export const restrictTensor = <J, A>(
+  family: TensorFamily<J, A>,
+  tensor: TensorElement<J, A>,
+  subset: FiniteSubset<J>,
+): TensorElement<J, A> => {
+  const allowed = new Set(subset.map((index) => keyOf(family, index)));
+  const terms: Array<{ coefficient: bigint; entries: ReadonlyArray<{ index: J; value: A }> }> = [];
+  for (const term of tensor.terms) {
+    const entries = term.entries
+      .filter((entry) => allowed.has(entry.key))
+      .map(({ index, value }) => ({ index, value }));
+    terms.push({ coefficient: term.coefficient, entries });
+  }
+  return normalizeElement(family, terms);
+};
+
+export interface FilteredInclusion<J, A> {
+  readonly smaller: FiniteSubset<J>;
+  readonly larger: FiniteSubset<J>;
+  readonly samples: ReadonlyArray<TensorElement<J, A>>;
+}
+
+export interface InclusionFailure<J, A> {
+  readonly smaller: FiniteSubset<J>;
+  readonly larger: FiniteSubset<J>;
+  readonly sample: TensorElement<J, A>;
+  readonly reason: string;
+}
+
+const equalTensors = <J, A>(
+  family: TensorFamily<J, A>,
+  left: TensorElement<J, A>,
+  right: TensorElement<J, A>,
+): boolean => {
+  if (left.terms.length !== right.terms.length) return false;
+  for (let i = 0; i < left.terms.length; i++) {
+    const a = left.terms[i];
+    const b = right.terms[i];
+    if (a.coefficient !== b.coefficient) return false;
+    if (a.entries.length !== b.entries.length) return false;
+    for (let j = 0; j < a.entries.length; j++) {
+      const ae = a.entries[j];
+      const be = b.entries[j];
+      if (ae.key !== be.key) return false;
+      const { object } = getComponent(family, ae.index);
+      if (!object.ring.eq(ae.value, be.value)) return false;
+    }
+  }
+  return true;
+};
+
+export interface FilteredColimitWitness<J, A> {
+  readonly family: TensorFamily<J, A>;
+  readonly include: (
+    smaller: FiniteSubset<J>,
+    larger: FiniteSubset<J>,
+    element: TensorElement<J, A>,
+  ) => TensorElement<J, A>;
+  readonly restrict: (
+    element: TensorElement<J, A>,
+    subset: FiniteSubset<J>,
+  ) => TensorElement<J, A>;
+  readonly support: (element: TensorElement<J, A>) => FiniteSubset<J>;
+}
+
+export const defaultFilteredWitness = <J, A>(family: TensorFamily<J, A>): FilteredColimitWitness<J, A> => ({
+  family,
+  include: (_smaller, _larger, element) => element,
+  restrict: (element, subset) => restrictTensor(family, element, subset),
+  support: (element) => tensorSupport(family, element),
+});
+
+export interface FilteredCompatibilityResult<J, A> {
+  readonly holds: boolean;
+  readonly failures: ReadonlyArray<InclusionFailure<J, A>>;
+  readonly details: string;
+}
+
+export const checkFilteredCompatibility = <J, A>(
+  witness: FilteredColimitWitness<J, A>,
+  inclusions: ReadonlyArray<FilteredInclusion<J, A>>,
+): FilteredCompatibilityResult<J, A> => {
+  const failures: InclusionFailure<J, A>[] = [];
+  const { family } = witness;
+
+  for (const inclusion of inclusions) {
+    const { smaller, larger, samples } = inclusion;
+    const largerSet = new Set(larger.map((index) => keyOf(family, index)));
+    const smallerSet = new Set(smaller.map((index) => keyOf(family, index)));
+
+    for (const index of smallerSet) {
+      if (!largerSet.has(index)) {
+        failures.push({ smaller, larger, sample: zeroTensor(family), reason: "Smaller subset not contained in larger." });
+        break;
+      }
+    }
+
+    for (const sample of samples) {
+      const support = witness.support(sample);
+      const supportKeys = new Set(support.map((index) => keyOf(family, index)));
+      for (const index of supportKeys) {
+        if (!smallerSet.has(index)) {
+          failures.push({ smaller, larger, sample, reason: "Sample support exceeds smaller subset." });
+          break;
+        }
+      }
+
+      const included = witness.include(smaller, larger, sample);
+      const restricted = witness.restrict(included, smaller);
+      if (!equalTensors(family, restricted, sample)) {
+        failures.push({ smaller, larger, sample, reason: "Restriction after inclusion differs from original." });
+      }
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All ${inclusions.length} filtered compatibility checks succeeded.`
+    : `${failures.length} filtered compatibility violation${failures.length === 1 ? "" : "s"}.`;
+
+  return { holds, failures, details };
+};
+
+export interface ColimitCoverageFailure<J, A> {
+  readonly sample: TensorElement<J, A>;
+  readonly support: FiniteSubset<J>;
+  readonly recovered: TensorElement<J, A>;
+}
+
+export interface ColimitCoverageResult<J, A> {
+  readonly holds: boolean;
+  readonly failures: ReadonlyArray<ColimitCoverageFailure<J, A>>;
+  readonly details: string;
+}
+
+export const checkColimitCoverage = <J, A>(
+  witness: FilteredColimitWitness<J, A>,
+  samples: ReadonlyArray<TensorElement<J, A>>,
+): ColimitCoverageResult<J, A> => {
+  const failures: ColimitCoverageFailure<J, A>[] = [];
+
+  for (const sample of samples) {
+    const support = witness.support(sample);
+    const recovered = witness.include(support, support, witness.restrict(sample, support));
+    if (!equalTensors(witness.family, recovered, sample)) {
+      failures.push({ sample, support, recovered });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All ${samples.length} samples recovered from their finite supports.`
+    : `${failures.length} sample${failures.length === 1 ? "" : "s"} failed finite-support recovery.`;
+
+  return { holds, failures, details };
+};
+
+// ✅ END_MATH: CRingPlusFilteredTensorColimit

--- a/cring-plus.ts
+++ b/cring-plus.ts
@@ -1,0 +1,459 @@
+// 🔮 BEGIN_MATH: CRingPlusSemicartesian
+// 📝 Brief: Instantiate semicartesian structure for additive/unit maps between commutative rings
+// 🏗️ Domain: Algebra / symmetric monoidal categories
+// 🔗 Integration: Reuses semicartesian initial-object oracle for the CRing_⊕ category
+// 📋 Plan:
+//   1. Model CRing_⊕ objects and additive/unit-preserving morphisms.
+//   2. Provide helpers for canonical maps from ℤ and equality checks.
+//   3. Use the generic semicartesian oracle to certify the initial-object semicartesian witness.
+
+import type { Ring } from "./ring";
+import { RingInteger } from "./ring";
+import {
+  type InitialArrowSample,
+  type InitialObjectWitness,
+  type InitialUnitSemicartesianData,
+  type InitialUnitSemicartesianResult,
+  type SemicartesianStructure,
+  checkInitialUnitSemicartesian,
+  deriveSemicartesianFromInitial,
+} from "./semicartesian-structure";
+
+export interface CRingPlusObject<A> {
+  readonly ring: Ring<A>;
+  readonly sample: ReadonlyArray<A>;
+  readonly name: string;
+  readonly format?: (value: A) => string;
+}
+
+export interface CRingPlusHom<A, B> {
+  readonly source: CRingPlusObject<A>;
+  readonly target: CRingPlusObject<B>;
+  readonly map: (value: A) => B;
+  readonly label?: string;
+}
+
+export type CRingPlusObj = CRingPlusObject<any>;
+export type CRingPlusMor = CRingPlusHom<any, any>;
+
+type HomCheck = { description: string };
+
+const normalizeMod = (value: bigint, modulus: bigint): bigint => {
+  if (modulus === 0n) return value;
+  const mod = value % modulus;
+  return mod >= 0n ? mod : mod + modulus;
+};
+
+const ringMod = (modulus: bigint): Ring<bigint> => ({
+  add: (a, b) => normalizeMod(a + b, modulus),
+  zero: normalizeMod(0n, modulus),
+  mul: (a, b) => normalizeMod(a * b, modulus),
+  one: normalizeMod(1n, modulus),
+  eq: (a, b) => normalizeMod(a, modulus) === normalizeMod(b, modulus),
+  neg: (a) => normalizeMod(-a, modulus),
+  sub: (a, b) => normalizeMod(a - b, modulus),
+});
+
+const integerSamples: readonly bigint[] = Object.freeze([-2n, -1n, 0n, 1n, 2n]);
+
+export const IntegersObject: CRingPlusObject<bigint> = {
+  ring: RingInteger,
+  sample: integerSamples,
+  name: "ℤ",
+  format: (value) => `${value}`,
+};
+
+export const createModObject = (modulus: bigint): CRingPlusObject<bigint> => {
+  if (modulus <= 1n) throw new Error("Modulus must exceed 1 to form a nontrivial ring");
+  const ring = ringMod(modulus);
+  const baseline = [0n, 1n, -1n, 2n, modulus - 1n];
+  const sample = Array.from(
+    new Set(baseline.map((value) => normalizeMod(value, modulus)))
+  );
+  return {
+    ring,
+    sample,
+    name: `ℤ/${modulus}ℤ`,
+    format: (value) => `${normalizeMod(value, modulus)} (mod ${modulus})`,
+  };
+};
+
+export const identityHom = <A>(object: CRingPlusObject<A>): CRingPlusHom<A, A> => ({
+  source: object,
+  target: object,
+  map: (value) => value,
+  label: `id_${object.name}`,
+});
+
+export const composeHom = <A, B, C>(
+  g: CRingPlusHom<B, C>,
+  f: CRingPlusHom<A, B>
+): CRingPlusHom<A, C> => {
+  if (f.target !== g.source) {
+    throw new Error("Cannot compose morphisms with mismatched domains/codomains");
+  }
+  return {
+    source: f.source,
+    target: g.target,
+    map: (value) => g.map(f.map(value)),
+    label: g.label && f.label ? `${g.label} ∘ ${f.label}` : undefined,
+  };
+};
+
+const integerAction = <A>(ring: Ring<A>, value: bigint): A => {
+  if (value === 0n) return ring.zero;
+  const positive = value < 0n ? -value : value;
+  let acc = ring.zero;
+  for (let i = 0n; i < positive; i++) {
+    acc = ring.add(acc, ring.one);
+  }
+  return value < 0n ? ring.neg(acc) : acc;
+};
+
+export const canonicalInitialHom = <A>(
+  target: CRingPlusObject<A>
+): CRingPlusHom<bigint, A> => ({
+  source: IntegersObject,
+  target,
+  map: (value) => integerAction(target.ring, value),
+  label: `ι_${target.name}`,
+});
+
+export const equalHom = <A, B>(
+  f: CRingPlusHom<A, B>,
+  g: CRingPlusHom<A, B>
+): boolean => {
+  if (f.source !== g.source || f.target !== g.target) return false;
+  const eq = f.target.ring.eq;
+  for (const sample of f.source.sample) {
+    const fx = f.map(sample);
+    const gx = g.map(sample);
+    if (!eq(fx, gx)) return false;
+  }
+  return true;
+};
+
+export const checkAdditiveUnitHom = <A, B>(
+  hom: CRingPlusHom<A, B>
+): { holds: boolean; failures: ReadonlyArray<HomCheck>; details: string } => {
+  const { source, target } = hom;
+  const failures: HomCheck[] = [];
+
+  const zeroPreserved = target.ring.eq(hom.map(source.ring.zero), target.ring.zero);
+  if (!zeroPreserved) failures.push({ description: "Does not send 0 to 0" });
+
+  const onePreserved = target.ring.eq(hom.map(source.ring.one), target.ring.one);
+  if (!onePreserved) failures.push({ description: "Does not send 1 to 1" });
+
+  for (const x of source.sample) {
+    for (const y of source.sample) {
+      const lhs = hom.map(source.ring.add(x, y));
+      const rhs = target.ring.add(hom.map(x), hom.map(y));
+      if (!target.ring.eq(lhs, rhs)) {
+        failures.push({ description: `Addition mismatch on (${source.format?.(x) ?? x}, ${source.format?.(y) ?? y})` });
+        break;
+      }
+    }
+  }
+
+  for (const x of source.sample) {
+    const lhs = hom.map(source.ring.neg(x));
+    const rhs = target.ring.neg(hom.map(x));
+    if (!target.ring.eq(lhs, rhs)) {
+      failures.push({ description: `Negation mismatch on ${source.format?.(x) ?? x}` });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `Homomorphism preserves additive structure across ${source.sample.length} samples.`
+    : `${failures.length} additive/unit constraints violated.`;
+
+  return { holds, failures, details };
+};
+
+const CRingPlusInitialWitness: InitialObjectWitness<CRingPlusObj, CRingPlusMor> = {
+  object: IntegersObject,
+  morphismTo: (target) => canonicalInitialHom(target),
+  isCanonical: (target, candidate) => {
+    if (candidate.source !== IntegersObject) return false;
+    if (candidate.target !== target) return false;
+    return equalHom(candidate, canonicalInitialHom(target));
+  },
+  describe: (target) => `ℤ → ${target.name}`,
+};
+
+export const CRingPlusInitialData: InitialUnitSemicartesianData<CRingPlusObj, CRingPlusMor> = {
+  unit: IntegersObject,
+  witness: CRingPlusInitialWitness,
+};
+
+export const semicartesianStructureCRingPlus = (): SemicartesianStructure<CRingPlusObj, CRingPlusMor> =>
+  deriveSemicartesianFromInitial(CRingPlusInitialData);
+
+export const checkCRingPlusInitialSemicartesian = (
+  targets: ReadonlyArray<CRingPlusObj>,
+  samples: ReadonlyArray<InitialArrowSample<CRingPlusObj, CRingPlusMor>> = []
+): InitialUnitSemicartesianResult<CRingPlusObj, CRingPlusMor> =>
+  checkInitialUnitSemicartesian(CRingPlusInitialData, targets, samples);
+
+// ✅ END_MATH: CRingPlusSemicartesian
+// 🔮 Oracles: checkCRingPlusInitialSemicartesian
+// 📜 Laws: ℤ as initial object induces semicartesian structure on CRing_⊕
+// 🧪 Tests: Dedicated semicartesian law spec with additive/unit hom checks and counterexamples
+// 📊 Coverage: CRing_⊕ objects plus reusable hom utilities and semicartesian witness
+
+// 🔮 BEGIN_MATH: CRingPlusCausalityCounterexample
+// 📝 Brief: Encode the causality counterexample showing CRing_⊕ violates the no-signalling principle.
+// 🏗️ Domain: Commutative rigs with coproducts; additive/unit preserving morphisms.
+// 🔗 Integration: Reuses CRing_⊕ hom utilities to package f, g, h₁, h₂ together with executable diagnostics.
+// 📋 Plan:
+//   1. Model ℤ[t] as a CRing_⊕ object with polynomial arithmetic over bigint coefficients.
+//   2. Provide evaluation homs (p ↦ p(a)) and the shift hom (p ↦ p(t+1)) used in the paper.
+//   3. Build and analyze the f, g, h₁, h₂ composite witnessing non-causality.
+
+export type Polynomial = ReadonlyArray<bigint>;
+
+const trimPolynomial = (coeffs: ReadonlyArray<bigint>): bigint[] => {
+  let end = coeffs.length - 1;
+  while (end >= 0 && coeffs[end] === 0n) end -= 1;
+  if (end < 0) return [];
+  return coeffs.slice(0, end + 1);
+};
+
+const addPolynomial = (a: ReadonlyArray<bigint>, b: ReadonlyArray<bigint>): bigint[] => {
+  const length = Math.max(a.length, b.length);
+  const acc = new Array<bigint>(length).fill(0n);
+  for (let i = 0; i < length; i += 1) {
+    const ai = i < a.length ? a[i] : 0n;
+    const bi = i < b.length ? b[i] : 0n;
+    acc[i] = ai + bi;
+  }
+  return trimPolynomial(acc);
+};
+
+const negPolynomial = (poly: ReadonlyArray<bigint>): bigint[] =>
+  poly.map((coeff) => -coeff);
+
+const subPolynomial = (a: ReadonlyArray<bigint>, b: ReadonlyArray<bigint>): bigint[] =>
+  addPolynomial(a, negPolynomial(b));
+
+const mulPolynomial = (a: ReadonlyArray<bigint>, b: ReadonlyArray<bigint>): bigint[] => {
+  if (a.length === 0 || b.length === 0) return [];
+  const acc = new Array<bigint>(a.length + b.length - 1).fill(0n);
+  for (let i = 0; i < a.length; i += 1) {
+    for (let j = 0; j < b.length; j += 1) {
+      acc[i + j] += a[i] * b[j];
+    }
+  }
+  return trimPolynomial(acc);
+};
+
+const eqPolynomial = (a: ReadonlyArray<bigint>, b: ReadonlyArray<bigint>): boolean => {
+  const ta = trimPolynomial(a);
+  const tb = trimPolynomial(b);
+  if (ta.length !== tb.length) return false;
+  for (let i = 0; i < ta.length; i += 1) {
+    if (ta[i] !== tb[i]) return false;
+  }
+  return true;
+};
+
+const constantPolynomial = (value: bigint): bigint[] =>
+  value === 0n ? [] : [value];
+
+const monomial = (degree: number): bigint[] => {
+  if (degree < 0) throw new Error("Monomial degree must be nonnegative");
+  const coeffs = new Array<bigint>(degree + 1).fill(0n);
+  coeffs[degree] = 1n;
+  return coeffs;
+};
+
+const polynomialSamples: ReadonlyArray<Polynomial> = Object.freeze([
+  constantPolynomial(0n),
+  constantPolynomial(1n),
+  constantPolynomial(2n),
+  monomial(1),
+  addPolynomial(constantPolynomial(1n), monomial(1)),
+  monomial(2),
+  addPolynomial(constantPolynomial(-1n), monomial(3)),
+]);
+
+const evaluatePolynomial = (poly: ReadonlyArray<bigint>, point: bigint): bigint => {
+  let result = 0n;
+  for (let i = poly.length - 1; i >= 0; i -= 1) {
+    result = result * point + poly[i];
+  }
+  return result;
+};
+
+const binomial = (n: number, k: number): bigint => {
+  if (k < 0 || k > n) return 0n;
+  if (k === 0 || k === n) return 1n;
+  let result = 1n;
+  for (let i = 1; i <= k; i += 1) {
+    result = (result * BigInt(n - k + i)) / BigInt(i);
+  }
+  return result;
+};
+
+const shiftPolynomial = (poly: ReadonlyArray<bigint>): bigint[] => {
+  let acc: bigint[] = [];
+  for (let degree = 0; degree < poly.length; degree += 1) {
+    const coeff = poly[degree];
+    if (coeff === 0n) continue;
+    const term = new Array<bigint>(degree + 1).fill(0n);
+    for (let i = 0; i <= degree; i += 1) {
+      term[i] = coeff * binomial(degree, i);
+    }
+    acc = addPolynomial(acc, term);
+  }
+  return acc;
+};
+
+const formatPolynomial = (poly: ReadonlyArray<bigint>): string => {
+  const trimmed = trimPolynomial(poly);
+  if (trimmed.length === 0) return "0";
+  const pieces: string[] = [];
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const coeff = trimmed[i];
+    if (coeff === 0n) continue;
+    const magnitude = coeff.toString();
+    if (i === 0) {
+      pieces.push(magnitude);
+    } else if (i === 1) {
+      pieces.push(`${magnitude}·t`);
+    } else {
+      pieces.push(`${magnitude}·t^${i}`);
+    }
+  }
+  return pieces.join(" + ") || "0";
+};
+
+export const PolynomialRing: Ring<Polynomial> = {
+  add: addPolynomial,
+  zero: [],
+  mul: mulPolynomial,
+  one: [1n],
+  eq: eqPolynomial,
+  neg: negPolynomial,
+  sub: subPolynomial,
+};
+
+export const PolynomialObject: CRingPlusObject<Polynomial> = {
+  ring: PolynomialRing,
+  sample: polynomialSamples,
+  name: "ℤ[t]",
+  format: formatPolynomial,
+};
+
+const evaluationHom = (value: bigint): CRingPlusHom<Polynomial, Polynomial> => ({
+  source: PolynomialObject,
+  target: PolynomialObject,
+  map: (poly) => constantPolynomial(evaluatePolynomial(poly, value)),
+  label: `ev_{t=${value.toString()}}`,
+});
+
+const shiftHom: CRingPlusHom<Polynomial, Polynomial> = {
+  source: PolynomialObject,
+  target: PolynomialObject,
+  map: (poly) => shiftPolynomial(poly),
+  label: "shift(t ↦ t+1)",
+};
+
+export interface CRingPlusCausalityScenario {
+  readonly object: CRingPlusObject<Polynomial>;
+  readonly observe: CRingPlusHom<Polynomial, Polynomial>;
+  readonly future: CRingPlusHom<Polynomial, Polynomial>;
+  readonly pastCanonical: CRingPlusHom<Polynomial, Polynomial>;
+  readonly pastIdentity: CRingPlusHom<Polynomial, Polynomial>;
+}
+
+export const buildCRingPlusCausalityScenario = (): CRingPlusCausalityScenario => ({
+  object: PolynomialObject,
+  observe: evaluationHom(0n),
+  future: shiftHom,
+  pastCanonical: evaluationHom(1n),
+  pastIdentity: identityHom(PolynomialObject),
+});
+
+export interface CRingPlusCausalityAnalysis {
+  readonly holds: boolean;
+  readonly equalAfterObservation: boolean;
+  readonly equalBeforeObservation: boolean;
+  readonly witness?: {
+    readonly input: Polynomial;
+    readonly before: Polynomial;
+    readonly after: Polynomial;
+  };
+  readonly homChecks: {
+    readonly observe: ReturnType<typeof checkAdditiveUnitHom>;
+    readonly future: ReturnType<typeof checkAdditiveUnitHom>;
+    readonly pastCanonical: ReturnType<typeof checkAdditiveUnitHom>;
+    readonly pastIdentity: ReturnType<typeof checkAdditiveUnitHom>;
+  };
+  readonly details: string;
+}
+
+export const checkCRingPlusCausalityCounterexample = (
+  scenario: CRingPlusCausalityScenario = buildCRingPlusCausalityScenario()
+): CRingPlusCausalityAnalysis => {
+  const { object, observe, future, pastCanonical, pastIdentity } = scenario;
+  const futureAfterCanonical = composeHom(future, pastCanonical);
+  const futureAfterIdentity = composeHom(future, pastIdentity);
+  const observedCanonical = composeHom(observe, futureAfterCanonical);
+  const observedIdentity = composeHom(observe, futureAfterIdentity);
+
+  const equalObservation = equalHom(observedCanonical, observedIdentity);
+  const equalFuture = equalHom(futureAfterCanonical, futureAfterIdentity);
+
+  let witness: CRingPlusCausalityAnalysis["witness"];
+  if (!equalFuture) {
+    for (const input of object.sample) {
+      const lhs = futureAfterCanonical.map(input);
+      const rhs = futureAfterIdentity.map(input);
+      if (!PolynomialRing.eq(lhs, rhs)) {
+        witness = { input, before: lhs, after: rhs };
+        break;
+      }
+    }
+  }
+
+  const homChecks = {
+    observe: checkAdditiveUnitHom(observe),
+    future: checkAdditiveUnitHom(future),
+    pastCanonical: checkAdditiveUnitHom(pastCanonical),
+    pastIdentity: checkAdditiveUnitHom(pastIdentity),
+  } as const;
+
+  const holds = equalObservation && !equalFuture;
+  const details = holds
+    ? "CRing_⊕ morphisms satisfy the causal premise but violate its conclusion."
+    : "Causality counterexample conditions not met.";
+
+  return {
+    holds,
+    equalAfterObservation: equalObservation,
+    equalBeforeObservation: equalFuture,
+    witness,
+    homChecks,
+    details,
+  };
+};
+
+export const polynomialEvaluate = (poly: Polynomial, point: bigint): bigint =>
+  evaluatePolynomial(poly, point);
+
+export const polynomialShift = (poly: Polynomial): Polynomial => shiftPolynomial(poly);
+
+export const polynomialConstant = (value: bigint): Polynomial => constantPolynomial(value);
+
+export const polynomialMonomial = (degree: number): Polynomial => monomial(degree);
+
+export const polynomialFormat = (poly: Polynomial): string => formatPolynomial(poly);
+
+// ✅ END_MATH: CRingPlusCausalityCounterexample
+// 🔮 Oracles: checkCRingPlusCausalityCounterexample
+// 📜 Laws: CRing_⊕ violates the causality axiom
+// 🧪 Tests: law.CRingPlusCausalityCounterexample.spec.ts exercising equality after observation and inequality before
+// 📊 Coverage: Polynomial ℤ[t] object, evaluation/shift homs, and counterexample diagnostics

--- a/cstar-algebra.ts
+++ b/cstar-algebra.ts
@@ -1,0 +1,409 @@
+// \ud83d\udd2e BEGIN_MATH: CStarAlgebra
+// \ud83d\udcdd Brief: Provide C*-algebra interfaces, complex-number instance, and executable oracles.
+// \ud83c\udfd7\ufe0f Domain: Functional analysis / operator algebras
+// \ud83d\udd17 Integration: Supplies reusable C*-algebra witnesses and morphism checks for the algebra registry
+// \ud83d\udccb Plan:
+//   1. Model complex numbers and general C*-algebra operations with tolerance-aware equality.
+//   2. Implement oracle helpers validating the C*-axioms and *-homomorphism behaviour.
+//   3. Package the canonical complex-number C*-algebra together with default diagnostics.
+
+export interface ComplexNumber {
+  readonly re: number;
+  readonly im: number;
+}
+
+export const complex = (re: number, im = 0): ComplexNumber => ({ re, im });
+
+const HALF = complex(0.5, 0);
+const NEG_HALF_I = complex(0, -0.5);
+const I = complex(0, 1);
+
+export const addComplex = (a: ComplexNumber, b: ComplexNumber): ComplexNumber =>
+  complex(a.re + b.re, a.im + b.im);
+
+export const negComplex = (a: ComplexNumber): ComplexNumber => complex(-a.re, -a.im);
+
+export const mulComplex = (a: ComplexNumber, b: ComplexNumber): ComplexNumber =>
+  complex(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re);
+
+export const conjComplex = (a: ComplexNumber): ComplexNumber => complex(a.re, -a.im);
+
+export const absComplex = (a: ComplexNumber): number => Math.hypot(a.re, a.im);
+
+export const eqComplex = (a: ComplexNumber, b: ComplexNumber, tolerance = 1e-9): boolean =>
+  Math.abs(a.re - b.re) <= tolerance && Math.abs(a.im - b.im) <= tolerance;
+
+export const realPartCStar = <A>(algebra: CStarAlgebra<A>, x: A): A =>
+  algebra.scalar(HALF, algebra.add(x, algebra.star(x)));
+
+export const imaginaryPartCStar = <A>(algebra: CStarAlgebra<A>, x: A): A =>
+  algebra.scalar(NEG_HALF_I, algebra.add(x, algebra.neg(algebra.star(x))));
+
+export const isSelfAdjoint = <A>(algebra: CStarAlgebra<A>, x: A, tolerance = 1e-9): boolean =>
+  algebra.equal(x, algebra.star(x), tolerance);
+
+export const isNormal = <A>(algebra: CStarAlgebra<A>, x: A, tolerance = 1e-9): boolean => {
+  const star = algebra.star(x);
+  return algebra.equal(algebra.mul(x, star), algebra.mul(star, x), tolerance);
+};
+
+export interface CStarAlgebra<A> {
+  readonly add: (a: A, b: A) => A;
+  readonly zero: A;
+  readonly neg: (a: A) => A;
+  readonly mul: (a: A, b: A) => A;
+  readonly one: A;
+  readonly scalar: (scalar: ComplexNumber, a: A) => A;
+  readonly star: (a: A) => A;
+  readonly norm: (a: A) => number;
+  readonly equal: (a: A, b: A, tolerance?: number) => boolean;
+  readonly positive: (a: A, tolerance?: number) => boolean;
+  readonly describe?: (a: A) => string;
+}
+
+export interface CStarAxiomFailure<A> {
+  readonly axiom:
+    | "involution"
+    | "additivity"
+    | "multiplicativity"
+    | "scalarCompatibility"
+    | "norm"
+    | "positivity";
+  readonly elements: ReadonlyArray<A>;
+  readonly scalar?: ComplexNumber;
+  readonly discrepancy?: number;
+  readonly message: string;
+}
+
+export interface CStarAxiomReport<A> {
+  readonly holds: boolean;
+  readonly tolerance: number;
+  readonly failures: ReadonlyArray<CStarAxiomFailure<A>>;
+}
+
+const defaultDescribe = <A>(algebra: CStarAlgebra<A>, value: A): string =>
+  algebra.describe ? algebra.describe(value) : `${value}`;
+
+export function checkCStarAxioms<A>(
+  algebra: CStarAlgebra<A>,
+  elements: ReadonlyArray<A>,
+  scalars: ReadonlyArray<ComplexNumber>,
+  tolerance = 1e-9,
+): CStarAxiomReport<A> {
+  const failures: Array<CStarAxiomFailure<A>> = [];
+  const eq = (x: A, y: A) => algebra.equal(x, y, tolerance);
+
+  for (const x of elements) {
+    const starStar = algebra.star(algebra.star(x));
+    if (!eq(starStar, x)) {
+      failures.push({
+        axiom: "involution",
+        elements: [x],
+        message: `Star is not involutive on ${defaultDescribe(algebra, x)}.`,
+      });
+    }
+  }
+
+  for (const x of elements) {
+    for (const y of elements) {
+      const starSum = algebra.star(algebra.add(x, y));
+      const sumStar = algebra.add(algebra.star(x), algebra.star(y));
+      if (!eq(starSum, sumStar)) {
+        failures.push({
+          axiom: "additivity",
+          elements: [x, y],
+          message: `Star failed additivity on ${defaultDescribe(algebra, x)} and ${defaultDescribe(algebra, y)}.`,
+        });
+      }
+
+      const starProduct = algebra.star(algebra.mul(x, y));
+      const productStar = algebra.mul(algebra.star(y), algebra.star(x));
+      if (!eq(starProduct, productStar)) {
+        failures.push({
+          axiom: "multiplicativity",
+          elements: [x, y],
+          message: `Star failed multiplicativity on ${defaultDescribe(algebra, x)} and ${defaultDescribe(algebra, y)}.`,
+        });
+      }
+    }
+  }
+
+  for (const lambda of scalars) {
+    for (const x of elements) {
+      const mapped = algebra.star(algebra.scalar(lambda, x));
+      const expected = algebra.scalar(conjComplex(lambda), algebra.star(x));
+      if (!eq(mapped, expected)) {
+        failures.push({
+          axiom: "scalarCompatibility",
+          elements: [x],
+          scalar: lambda,
+          message: `Star failed scalar compatibility on ${defaultDescribe(algebra, x)} with scalar (${lambda.re} + ${lambda.im}i).`,
+        });
+      }
+    }
+  }
+
+  for (const x of elements) {
+    const lhs = algebra.norm(algebra.mul(algebra.star(x), x));
+    const rhs = Math.pow(algebra.norm(x), 2);
+    if (Math.abs(lhs - rhs) > tolerance) {
+      failures.push({
+        axiom: "norm",
+        elements: [x],
+        discrepancy: Math.abs(lhs - rhs),
+        message: `C*-identity failed on ${defaultDescribe(algebra, x)}: ||x* x|| = ${lhs}, ||x||^2 = ${rhs}.`,
+      });
+    }
+
+    const positiveCandidate = algebra.mul(algebra.star(x), x);
+    if (!algebra.positive(positiveCandidate, tolerance)) {
+      failures.push({
+        axiom: "positivity",
+        elements: [x],
+        message: `x* x was not positive for ${defaultDescribe(algebra, x)}.`,
+      });
+    }
+  }
+
+  return { holds: failures.length === 0, tolerance, failures };
+}
+
+export interface CStarHomomorphism<A, B> {
+  readonly map: (value: A) => B;
+  readonly label?: string;
+}
+
+export interface CStarHomomorphismFailure<A> {
+  readonly law:
+    | "additive"
+    | "multiplicative"
+    | "scalar"
+    | "star"
+    | "unit"
+    | "zero"
+    | "norm";
+  readonly elements: ReadonlyArray<A>;
+  readonly scalar?: ComplexNumber;
+  readonly discrepancy?: number;
+  readonly message: string;
+}
+
+export interface CStarHomomorphismReport<A> {
+  readonly holds: boolean;
+  readonly tolerance: number;
+  readonly failures: ReadonlyArray<CStarHomomorphismFailure<A>>;
+}
+
+export interface CStarSpectralEntry<A> {
+  readonly element: A;
+  readonly selfAdjoint: boolean;
+  readonly normal: boolean;
+  readonly realPart: A;
+  readonly imaginaryPart: A;
+  readonly realSelfAdjoint: boolean;
+  readonly imaginarySelfAdjoint: boolean;
+  readonly decompositionValid: boolean;
+  readonly discrepancy: number;
+}
+
+export interface CStarSpectralReport<A> {
+  readonly holds: boolean;
+  readonly tolerance: number;
+  readonly entries: ReadonlyArray<CStarSpectralEntry<A>>;
+}
+
+export function checkCStarHomomorphism<A, B>(
+  source: CStarAlgebra<A>,
+  target: CStarAlgebra<B>,
+  hom: CStarHomomorphism<A, B>,
+  elements: ReadonlyArray<A>,
+  scalars: ReadonlyArray<ComplexNumber>,
+  tolerance = 1e-9,
+): CStarHomomorphismReport<A> {
+  const failures: Array<CStarHomomorphismFailure<A>> = [];
+  const label = hom.label ?? "homomorphism";
+  const eqTarget = (x: B, y: B) => target.equal(x, y, tolerance);
+
+  if (!eqTarget(hom.map(source.zero), target.zero)) {
+    failures.push({
+      law: "zero",
+      elements: [],
+      message: `${label} failed to preserve zero.`,
+    });
+  }
+
+  if (!eqTarget(hom.map(source.one), target.one)) {
+    failures.push({
+      law: "unit",
+      elements: [],
+      message: `${label} failed to preserve the unit.`,
+    });
+  }
+
+  for (const x of elements) {
+    if (!eqTarget(hom.map(source.star(x)), target.star(hom.map(x)))) {
+      failures.push({
+        law: "star",
+        elements: [x],
+        message: `${label} does not preserve star on ${defaultDescribe(source, x)}.`,
+      });
+    }
+  }
+
+  for (const x of elements) {
+    for (const y of elements) {
+      const mapped = hom.map(source.add(x, y));
+      const expected = target.add(hom.map(x), hom.map(y));
+      if (!eqTarget(mapped, expected)) {
+        failures.push({
+          law: "additive",
+          elements: [x, y],
+          message: `${label} failed additivity on ${defaultDescribe(source, x)} and ${defaultDescribe(source, y)}.`,
+        });
+      }
+
+      const mappedProduct = hom.map(source.mul(x, y));
+      const expectedProduct = target.mul(hom.map(x), hom.map(y));
+      if (!eqTarget(mappedProduct, expectedProduct)) {
+        failures.push({
+          law: "multiplicative",
+          elements: [x, y],
+          message: `${label} failed multiplicativity on ${defaultDescribe(source, x)} and ${defaultDescribe(source, y)}.`,
+        });
+      }
+    }
+  }
+
+  for (const lambda of scalars) {
+    for (const x of elements) {
+      const mapped = hom.map(source.scalar(lambda, x));
+      const expected = target.scalar(lambda, hom.map(x));
+      if (!eqTarget(mapped, expected)) {
+        failures.push({
+          law: "scalar",
+          elements: [x],
+          scalar: lambda,
+          message: `${label} failed scalar compatibility on ${defaultDescribe(source, x)} with scalar (${lambda.re} + ${lambda.im}i).`,
+        });
+      }
+    }
+  }
+
+  for (const x of elements) {
+    const mappedNorm = target.norm(hom.map(x));
+    const sourceNorm = source.norm(x);
+    if (mappedNorm - sourceNorm > tolerance) {
+      failures.push({
+        law: "norm",
+        elements: [x],
+        discrepancy: mappedNorm - sourceNorm,
+        message: `${label} was not contractive on ${defaultDescribe(source, x)}.`,
+      });
+    }
+  }
+
+  return { holds: failures.length === 0, tolerance, failures };
+}
+
+export function checkCStarSpectralTheory<A>(
+  algebra: CStarAlgebra<A>,
+  elements: ReadonlyArray<A>,
+  tolerance = 1e-9,
+): CStarSpectralReport<A> {
+  const entries = elements.map((element) => {
+    const selfAdjoint = isSelfAdjoint(algebra, element, tolerance);
+    const normal = isNormal(algebra, element, tolerance);
+    const realPart = realPartCStar(algebra, element);
+    const imaginaryPart = imaginaryPartCStar(algebra, element);
+    const realSelfAdjoint = isSelfAdjoint(algebra, realPart, tolerance);
+    const imaginarySelfAdjoint = isSelfAdjoint(algebra, imaginaryPart, tolerance);
+    const recomposed = algebra.add(realPart, algebra.scalar(I, imaginaryPart));
+    const discrepancyElement = algebra.add(recomposed, algebra.neg(element));
+    const discrepancy = algebra.norm(discrepancyElement);
+    const decompositionValid = discrepancy <= tolerance;
+    const entry: CStarSpectralEntry<A> = {
+      element,
+      selfAdjoint,
+      normal,
+      realPart,
+      imaginaryPart,
+      realSelfAdjoint,
+      imaginarySelfAdjoint,
+      decompositionValid,
+      discrepancy,
+    };
+    return entry;
+  });
+
+  const holds = entries.every(
+    (entry) => entry.realSelfAdjoint && entry.imaginarySelfAdjoint && entry.decompositionValid,
+  );
+
+  return { holds, tolerance, entries };
+}
+
+const describeComplex = (value: ComplexNumber): string =>
+  `${value.re}${value.im >= 0 ? "+" : ""}${value.im}i`;
+
+export const ComplexCStarAlgebra: CStarAlgebra<ComplexNumber> = {
+  add: addComplex,
+  zero: complex(0, 0),
+  neg: negComplex,
+  mul: mulComplex,
+  one: complex(1, 0),
+  scalar: mulComplex,
+  star: conjComplex,
+  norm: absComplex,
+  equal: (a, b, tolerance = 1e-9) => eqComplex(a, b, tolerance),
+  positive: (a, tolerance = 1e-9) => Math.abs(a.im) <= tolerance && a.re >= -tolerance,
+  describe: describeComplex,
+};
+
+const defaultComplexSamples: ReadonlyArray<ComplexNumber> = [
+  complex(0, 0),
+  complex(1, 0),
+  complex(0, 1),
+  complex(-2, 3),
+];
+
+const defaultScalars: ReadonlyArray<ComplexNumber> = [
+  complex(1, 0),
+  complex(0, 1),
+  complex(2, -1),
+];
+
+export const identityComplexHom: CStarHomomorphism<ComplexNumber, ComplexNumber> = {
+  map: (value) => value,
+  label: "id_ℂ",
+};
+
+export const checkComplexCStarAxioms = (
+  samples: ReadonlyArray<ComplexNumber> = defaultComplexSamples,
+  scalars: ReadonlyArray<ComplexNumber> = defaultScalars,
+  tolerance = 1e-9,
+): CStarAxiomReport<ComplexNumber> =>
+  checkCStarAxioms(ComplexCStarAlgebra, samples, scalars, tolerance);
+
+export const checkComplexIdentityHomomorphism = (
+  samples: ReadonlyArray<ComplexNumber> = defaultComplexSamples,
+  scalars: ReadonlyArray<ComplexNumber> = defaultScalars,
+  tolerance = 1e-9,
+): CStarHomomorphismReport<ComplexNumber> =>
+  checkCStarHomomorphism(
+    ComplexCStarAlgebra,
+    ComplexCStarAlgebra,
+    identityComplexHom,
+    samples,
+    scalars,
+    tolerance,
+  );
+
+export const checkComplexSpectralTheory = (
+  samples: ReadonlyArray<ComplexNumber> = defaultComplexSamples,
+  tolerance = 1e-9,
+): CStarSpectralReport<ComplexNumber> => checkCStarSpectralTheory(ComplexCStarAlgebra, samples, tolerance);
+
+// \u2705 END_MATH: CStarAlgebra
+// \ud83d\udd2e Oracles: checkCStarAxioms, checkCStarHomomorphism, checkComplexCStarAxioms, checkComplexIdentityHomomorphism, checkCStarSpectralTheory, checkComplexSpectralTheory
+// \ud83d\udcdc Laws: C*-algebra axioms for complex numbers, *-homomorphism contractivity, and spectral-theory decomposition
+// \ud83d\udcc8 Tests: law.CStarAlgebra.spec.ts exercising axioms, homomorphism diagnostics, and spectral decomposition

--- a/markov-almost-sure.ts
+++ b/markov-almost-sure.ts
@@ -1,0 +1,196 @@
+// 🔮 BEGIN_MATH: MarkovAlmostSureEquality
+// 📝 Brief: Recognize p-almost-sure equality between Markov kernels.
+// 🏗️ Domain: Finite Markov categories with explicit copy/discard structure.
+// 🔗 Integration: Extends FinMarkov tooling with witnesses, support tracking, and executable oracles.
+// 📋 Plan:
+//   1. Bundle the morphisms (p, f, g) into a reusable witness with label metadata.
+//   2. Analyze the support of p to identify which X-values matter for almost-sure comparison.
+//   3. Compare f and g on that support, report counterexamples, and expose the shared composite when they agree.
+
+import type { Eq, Kernel } from "./markov-category";
+import { FinMarkov, MarkovCategory } from "./markov-category";
+
+const DEFAULT_TOLERANCE = 1e-9;
+
+function pushUnique<T>(list: T[], value: T, eq: Eq<T>): void {
+  if (!list.some((item) => eq(item, value))) {
+    list.push(value);
+  }
+}
+
+interface SupportContribution<A> {
+  readonly input: A;
+  readonly weight: number;
+}
+
+export interface SupportRecord<A, X> {
+  readonly value: X;
+  readonly totalMass: number;
+  readonly contributions: ReadonlyArray<SupportContribution<A>>;
+}
+
+export interface DistributionDifference<Y> {
+  readonly value: Y;
+  readonly left: number;
+  readonly right: number;
+}
+
+export interface AlmostSureFailure<A, X, Y> {
+  readonly supportPoint: X;
+  readonly sources: ReadonlyArray<A>;
+  readonly differences: ReadonlyArray<DistributionDifference<Y>>;
+}
+
+export interface MarkovAlmostSureWitness<A, X, Y> {
+  readonly prior: FinMarkov<A, X>;
+  readonly left: FinMarkov<X, Y>;
+  readonly right: FinMarkov<X, Y>;
+  readonly label?: string;
+}
+
+export interface MarkovAlmostSureReport<A, X, Y> {
+  readonly holds: boolean;
+  readonly witness: MarkovAlmostSureWitness<A, X, Y>;
+  readonly tolerance: number;
+  readonly support: ReadonlyArray<SupportRecord<A, X>>;
+  readonly failures: ReadonlyArray<AlmostSureFailure<A, X, Y>>;
+  readonly leftComposite: FinMarkov<A, Y>;
+  readonly rightComposite: FinMarkov<A, Y>;
+  readonly composite?: FinMarkov<A, Y>;
+  readonly equalComposite: boolean;
+  readonly details: string;
+}
+
+export interface MarkovAlmostSureWitnessOptions {
+  readonly label?: string;
+}
+
+export interface MarkovAlmostSureCheckOptions {
+  readonly tolerance?: number;
+}
+
+export function buildMarkovAlmostSureWitness<A, X, Y>(
+  prior: FinMarkov<A, X>,
+  left: FinMarkov<X, Y>,
+  right: FinMarkov<X, Y>,
+  options: MarkovAlmostSureWitnessOptions = {},
+): MarkovAlmostSureWitness<A, X, Y> {
+  if (prior.Y !== left.X || prior.Y !== right.X) {
+    throw new Error("Almost-sure witness requires prior codomain to match left/right domains.");
+  }
+  if (left.Y !== right.Y) {
+    throw new Error("Almost-sure witness requires left/right codomains to agree.");
+  }
+  return { prior, left, right, label: options.label };
+}
+
+function findSupportRecord<A, X>(records: Array<{ value: X; totalMass: number; contributions: SupportContribution<A>[] }>, value: X, eq: Eq<X>) {
+  for (const record of records) {
+    if (eq(record.value, value)) return record;
+  }
+  return undefined;
+}
+
+function collectSupport<A, X>(prior: FinMarkov<A, X>, tolerance: number): SupportRecord<A, X>[] {
+  const records: Array<{ value: X; totalMass: number; contributions: SupportContribution<A>[] }> = [];
+  const { X: domain, Y: codomain } = prior;
+  for (const a of domain.elems) {
+    const dist = prior.k(a);
+    for (const [x, weight] of dist) {
+      if (weight <= tolerance) continue;
+      let record = findSupportRecord(records, x, codomain.eq);
+      if (!record) {
+        record = { value: x, totalMass: 0, contributions: [] };
+        records.push(record);
+      }
+      record.totalMass += weight;
+      const contrib = record.contributions.find((entry) => domain.eq(entry.input, a));
+      if (contrib) {
+        contrib.weight += weight;
+      } else {
+        record.contributions.push({ input: a, weight });
+      }
+    }
+  }
+  return records.map((record) => ({
+    value: record.value,
+    totalMass: record.totalMass,
+    contributions: record.contributions,
+  }));
+}
+
+function diffDistributions<X, Y>(
+  left: Kernel<X, Y>,
+  right: Kernel<X, Y>,
+  point: X,
+  tolerance: number,
+): DistributionDifference<Y>[] {
+  const dl = left(point);
+  const dr = right(point);
+  const values = new Set<Y>([...dl.keys(), ...dr.keys()]);
+  const diffs: DistributionDifference<Y>[] = [];
+  for (const y of values) {
+    const lv = dl.get(y) ?? 0;
+    const rv = dr.get(y) ?? 0;
+    if (Math.abs(lv - rv) > tolerance) {
+      diffs.push({ value: y, left: lv, right: rv });
+    }
+  }
+  return diffs;
+}
+
+export function checkAlmostSureEquality<A, X, Y>(
+  witness: MarkovAlmostSureWitness<A, X, Y>,
+  options: MarkovAlmostSureCheckOptions = {},
+): MarkovAlmostSureReport<A, X, Y> {
+  const tolerance = options.tolerance ?? DEFAULT_TOLERANCE;
+  const support = collectSupport(witness.prior, tolerance);
+
+  const failures: AlmostSureFailure<A, X, Y>[] = [];
+  for (const record of support) {
+    const differences = diffDistributions(witness.left.k, witness.right.k, record.value, tolerance);
+    if (differences.length > 0) {
+      const sources: A[] = [];
+      for (const contribution of record.contributions) {
+        pushUnique(sources, contribution.input, witness.prior.X.eq);
+      }
+      failures.push({ supportPoint: record.value, sources, differences });
+    }
+  }
+
+  const leftComposite = witness.prior.then(witness.left);
+  const rightComposite = witness.prior.then(witness.right);
+  const equalComposite = MarkovCategory.equalMor(leftComposite, rightComposite);
+
+  const holds = failures.length === 0;
+  const composite = holds ? leftComposite : undefined;
+  const descriptor = witness.label ?? "p-a.s. equality";
+  const details = holds
+    ? `Morphisms are ${descriptor} with shared composite on ${support.length} support point${support.length === 1 ? "" : "s"}.`
+    : `${failures.length} support point${failures.length === 1 ? "" : "s"} break almost-sure equality.`;
+
+  return {
+    holds,
+    witness,
+    tolerance,
+    support,
+    failures,
+    leftComposite,
+    rightComposite,
+    composite,
+    equalComposite,
+    details,
+  };
+}
+
+export function pAlmostSureEqual<A, X, Y>(
+  witness: MarkovAlmostSureWitness<A, X, Y>,
+  options: MarkovAlmostSureCheckOptions = {},
+): boolean {
+  return checkAlmostSureEquality(witness, options).holds;
+}
+
+// ✅ END_MATH: MarkovAlmostSureEquality
+// 🔮 Oracles: checkAlmostSureEquality, pAlmostSureEqual
+// 🧪 Tests: law.MarkovAlmostSureEquality.spec.ts
+// 📊 Coverage: Finite Markov kernels, extendable via projective witnesses for inverse limits

--- a/markov-comonoid-structure.ts
+++ b/markov-comonoid-structure.ts
@@ -1,0 +1,132 @@
+// 🔮 BEGIN_MATH: MarkovComonoidWitness
+// 📝 Brief: Package copy/discard data and expose executable comonoid oracles.
+// 🏗️ Domain: Markov categories / commutative comonoids in symmetric monoidal categories.
+// 🔗 Integration: Builds on markov-category.ts primitives and registers oracle-ready reports.
+// 📋 Plan:
+//   1. Capture canonical copy/discard morphisms as reusable witnesses.
+//   2. Provide oracle reports checking coassociativity, commutativity, and counit laws with diagnostics.
+//   3. Extend to homomorphism checks showing when kernels respect the comonoid structure.
+
+import type { Fin, Pair, Kernel, I, CopyDiscardLaws, ComonoidHomReport } from "./markov-category";
+import { copyK, discardK, checkComonoidLaws, checkComonoidHom, FinMarkov } from "./markov-category";
+
+export interface MarkovComonoidWitnessOptions<X> {
+  readonly label?: string;
+  readonly copy?: FinMarkov<X, Pair<X, X>>;
+  readonly discard?: FinMarkov<X, I>;
+}
+
+export interface MarkovComonoidWitness<X> {
+  readonly object: Fin<X>;
+  readonly copy: FinMarkov<X, Pair<X, X>>;
+  readonly discard: FinMarkov<X, I>;
+  readonly label?: string;
+}
+
+export interface ComonoidLawFailure {
+  readonly law: "coassociativity" | "commutativity" | "leftCounit" | "rightCounit";
+  readonly message: string;
+}
+
+export interface ComonoidHomFailure {
+  readonly law: "copy" | "discard";
+  readonly message: string;
+}
+
+export interface MarkovComonoidReport<X> extends CopyDiscardLaws {
+  readonly holds: boolean;
+  readonly witness: MarkovComonoidWitness<X>;
+  readonly details: string;
+  readonly failures: ReadonlyArray<ComonoidLawFailure>;
+}
+
+export interface MarkovComonoidHomReport<X, Y> extends ComonoidHomReport {
+  readonly holds: boolean;
+  readonly domain: MarkovComonoidWitness<X>;
+  readonly codomain: MarkovComonoidWitness<Y>;
+  readonly details: string;
+  readonly failures: ReadonlyArray<ComonoidHomFailure>;
+}
+
+function describeWitness<X>(witness: MarkovComonoidWitness<X>): string {
+  const size = witness.object.elems.length;
+  return witness.label ?? (size === 1 ? "terminal object" : `${size}-element object`);
+}
+
+export function buildMarkovComonoidWitness<X>(
+  object: Fin<X>,
+  options: MarkovComonoidWitnessOptions<X> = {},
+): MarkovComonoidWitness<X> {
+  const copy = options.copy ?? copyK(object);
+  const discard = options.discard ?? discardK(object);
+
+  if (copy.X !== object) {
+    throw new Error("Copy morphism domain does not match the provided object.");
+  }
+  if (discard.X !== object) {
+    throw new Error("Discard morphism domain does not match the provided object.");
+  }
+
+  return { object, copy, discard, label: options.label };
+}
+
+export function checkMarkovComonoid<X>(witness: MarkovComonoidWitness<X>): MarkovComonoidReport<X> {
+  const base = checkComonoidLaws(witness.object, {
+    copy: witness.copy.k as Kernel<X, Pair<X, X>>,
+    discard: witness.discard.k as Kernel<X, I>,
+  });
+
+  const failures: ComonoidLawFailure[] = [];
+  const descriptor = describeWitness(witness);
+
+  if (!base.copyCoassoc) {
+    failures.push({ law: "coassociativity", message: `Δ failed coassociativity on ${descriptor}.` });
+  }
+  if (!base.copyCommut) {
+    failures.push({ law: "commutativity", message: `Δ failed commutativity on ${descriptor}.` });
+  }
+  if (!base.copyCounitL) {
+    failures.push({ law: "leftCounit", message: `Left counit (! ⊗ id) ∘ Δ ≠ id on ${descriptor}.` });
+  }
+  if (!base.copyCounitR) {
+    failures.push({ law: "rightCounit", message: `Right counit (id ⊗ !) ∘ Δ ≠ id on ${descriptor}.` });
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `Copy Δ and discard ! witness a commutative comonoid on ${descriptor}.`
+    : `${failures.length} comonoid law${failures.length === 1 ? "" : "s"} failed on ${descriptor}.`;
+
+  return { ...base, holds, witness, details, failures };
+}
+
+export function checkMarkovComonoidHom<X, Y>(
+  domain: MarkovComonoidWitness<X>,
+  codomain: MarkovComonoidWitness<Y>,
+  morphism: Kernel<X, Y>,
+): MarkovComonoidHomReport<X, Y> {
+  const base = checkComonoidHom(domain.object, codomain.object, morphism);
+
+  const failures: ComonoidHomFailure[] = [];
+  const src = describeWitness(domain);
+  const tgt = describeWitness(codomain);
+
+  if (!base.preservesCopy) {
+    failures.push({ law: "copy", message: `Δ was not preserved by the morphism from ${src} to ${tgt}.` });
+  }
+  if (!base.preservesDiscard) {
+    failures.push({ law: "discard", message: `! was not preserved by the morphism from ${src} to ${tgt}.` });
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `Morphism preserves copy and discard between ${src} and ${tgt}.`
+    : `${failures.length} comonoid homomorphism condition${failures.length === 1 ? "" : "s"} failed from ${src} to ${tgt}.`;
+
+  return { ...base, holds, domain, codomain, details, failures };
+}
+
+// ✅ END_MATH: MarkovComonoidWitness
+// 🔮 Oracles: checkMarkovComonoid, checkMarkovComonoidHom
+// 🧪 Tests: Exercised via law.MarkovCategory.spec.ts property suites
+// 📊 Coverage: Finite Markov kernels, extendable to infinite objects via inverse-limit carriers

--- a/markov-conditional-independence.ts
+++ b/markov-conditional-independence.ts
@@ -1,0 +1,291 @@
+// 🔮 BEGIN_MATH: MarkovConditionalIndependence
+// 📝 Brief: Package conditional-independence witnesses and factorization oracles.
+// 🏗️ Domain: Finite Markov categories with explicit copy/discard structure.
+// 🔗 Integration: Builds on comonoid witnesses and Markov kernels to expose executable conditional-independence checks.
+// 📋 Plan:
+//   1. Package conditional-independence witnesses that record domain/output comonoids, codomain projections, and the kernel p.
+//   2. Provide helpers extracting conditional marginals, reconstructing the factorized kernel, and permuting tensor factors.
+//   3. Implement an oracle report that certifies conditional independence and optional permutation invariants with diagnostic failures.
+
+import type { Fin, Kernel } from "./markov-category";
+import { FinMarkov, tensorObj, pair, deterministic, approxEqualMatrix } from "./markov-category";
+import type { MarkovComonoidWitness } from "./markov-comonoid-structure";
+
+export interface MarkovConditionalWitnessOptions {
+  readonly label?: string;
+  readonly projections?: ReadonlyArray<FinMarkov<any, any>>;
+}
+
+export interface MarkovConditionalWitness<A> {
+  readonly domain: MarkovComonoidWitness<A>;
+  readonly outputs: ReadonlyArray<MarkovComonoidWitness<any>>;
+  readonly arrow: FinMarkov<A, any>;
+  readonly projections: ReadonlyArray<FinMarkov<any, any>>;
+  readonly label?: string;
+  readonly arity: number;
+}
+
+export interface ConditionalPermutationReport {
+  readonly permutation: ReadonlyArray<number>;
+  readonly holds: boolean;
+  readonly details: string;
+}
+
+export type ConditionalFailureLaw =
+  | "arity"
+  | "projection"
+  | "factorization"
+  | "permutation"
+  | "cardinality";
+
+export interface ConditionalFailure {
+  readonly law: ConditionalFailureLaw;
+  readonly message: string;
+  readonly permutation?: ReadonlyArray<number>;
+}
+
+export interface MarkovConditionalReport<A> {
+  readonly witness: MarkovConditionalWitness<A>;
+  readonly components: ReadonlyArray<FinMarkov<A, any>>;
+  readonly factorized: FinMarkov<A, any>;
+  readonly holds: boolean;
+  readonly equality: boolean;
+  readonly permutations: ReadonlyArray<ConditionalPermutationReport>;
+  readonly failures: ReadonlyArray<ConditionalFailure>;
+  readonly details: string;
+}
+
+function productCardinality(outputs: ReadonlyArray<MarkovComonoidWitness<any>>): number {
+  return outputs.reduce((acc, witness) => acc * witness.object.elems.length, 1);
+}
+
+function flattenProduct(value: unknown, arity: number): unknown[] {
+  if (arity <= 0) return [];
+  if (arity === 1) return [value];
+  if (!Array.isArray(value) || value.length !== 2) {
+    throw new Error("Expected a left-associated tensor Pair during flattening.");
+  }
+  const [prefix, last] = value as readonly [unknown, unknown];
+  const head = flattenProduct(prefix, arity - 1);
+  head.push(last);
+  return head;
+}
+
+function rebuildProduct(values: ReadonlyArray<unknown>): unknown {
+  if (values.length === 0) {
+    throw new Error("Cannot rebuild a tensor product with zero factors.");
+  }
+  let acc: unknown = values[0];
+  for (let i = 1; i < values.length; i++) {
+    acc = [acc, values[i]] as const;
+  }
+  return acc;
+}
+
+function extractCoordinate(value: unknown, index: number, arity: number): unknown {
+  const flat = flattenProduct(value, arity);
+  if (index < 0 || index >= flat.length) {
+    throw new Error(`Coordinate index ${index} is outside the tensor arity ${arity}.`);
+  }
+  return flat[index];
+}
+
+function validatePermutation(permutation: ReadonlyArray<number>, arity: number): void {
+  if (permutation.length !== arity) {
+    throw new Error(`Permutation length ${permutation.length} does not match arity ${arity}.`);
+  }
+  const seen = new Set<number>();
+  for (const idx of permutation) {
+    if (!Number.isInteger(idx)) throw new Error("Permutation entries must be integers.");
+    if (idx < 0 || idx >= arity) throw new Error(`Permutation index ${idx} is outside [0, ${arity}).`);
+    if (seen.has(idx)) throw new Error("Permutation repeats an index, violating bijectivity.");
+    seen.add(idx);
+  }
+}
+
+function buildProjection(
+  codomain: Fin<any>,
+  target: Fin<any>,
+  arity: number,
+  index: number,
+): FinMarkov<any, any> {
+  const proj = deterministic((value: unknown) => extractCoordinate(value, index, arity));
+  return new FinMarkov(codomain, target, proj as Kernel<any, any>);
+}
+
+function inferDefaultProjections(
+  codomain: Fin<any>,
+  outputs: ReadonlyArray<MarkovComonoidWitness<any>>,
+): ReadonlyArray<FinMarkov<any, any>> {
+  if (outputs.length === 0) {
+    throw new Error("Cannot infer projections without at least one output object.");
+  }
+  // Attempt to flatten each element to ensure the representation matches nested Pairs.
+  const arity = outputs.length;
+  if (codomain.elems.length > 0) {
+    for (const elem of codomain.elems) {
+      flattenProduct(elem, arity);
+    }
+  }
+  return outputs.map((output, index) => buildProjection(codomain, output.object, arity, index));
+}
+
+export function buildMarkovConditionalWitness<A>(
+  domain: MarkovComonoidWitness<A>,
+  outputs: ReadonlyArray<MarkovComonoidWitness<any>>,
+  arrow: FinMarkov<A, any>,
+  options: MarkovConditionalWitnessOptions = {},
+): MarkovConditionalWitness<A> {
+  if (arrow.X !== domain.object) {
+    throw new Error("Conditional witness domain mismatch between comonoid and arrow.");
+  }
+  if (outputs.length === 0) {
+    throw new Error("Conditional independence requires at least one output object.");
+  }
+  const projections = options.projections ?? inferDefaultProjections(arrow.Y, outputs);
+  if (projections.length !== outputs.length) {
+    throw new Error("Number of projections must match number of outputs.");
+  }
+  projections.forEach((projection, index) => {
+    const witness = outputs[index];
+    if (projection.X !== arrow.Y) {
+      throw new Error(`Projection ${index} does not consume the conditional kernel codomain.`);
+    }
+    if (projection.Y !== witness.object) {
+      throw new Error(`Projection ${index} does not target the expected output object.`);
+    }
+  });
+
+  return {
+    domain,
+    outputs,
+    arrow,
+    projections,
+    label: options.label,
+    arity: outputs.length,
+  };
+}
+
+export function conditionalMarginals<A>(
+  witness: MarkovConditionalWitness<A>,
+): ReadonlyArray<FinMarkov<A, any>> {
+  return witness.projections.map((projection) => witness.arrow.then(projection));
+}
+
+export function factorizeConditional<A>(witness: MarkovConditionalWitness<A>): FinMarkov<A, any> {
+  const components = conditionalMarginals(witness);
+  if (components.length === 0) {
+    throw new Error("Cannot factorize a conditional witness without components.");
+  }
+  let kernel: Kernel<A, any> = components[0].k;
+  let codomain: Fin<any> = components[0].Y;
+  for (let i = 1; i < components.length; i++) {
+    kernel = pair(kernel, components[i].k);
+    codomain = tensorObj(codomain, components[i].Y);
+  }
+  if (codomain.elems.length !== witness.arrow.Y.elems.length) {
+    throw new Error(
+      `Factorized codomain cardinality ${codomain.elems.length} differs from kernel codomain ${witness.arrow.Y.elems.length}.`,
+    );
+  }
+  return new FinMarkov(witness.domain.object, witness.arrow.Y, kernel);
+}
+
+function permutationKernel(
+  codomain: Fin<any>,
+  arity: number,
+  permutation: ReadonlyArray<number>,
+): FinMarkov<any, any> {
+  validatePermutation(permutation, arity);
+  const action = deterministic((value: unknown) => {
+    const flat = flattenProduct(value, arity);
+    const permuted = permutation.map((idx) => flat[idx]);
+    return rebuildProduct(permuted);
+  });
+  return new FinMarkov(codomain, codomain, action as Kernel<any, any>);
+}
+
+export interface ConditionalIndependenceOptions {
+  readonly permutations?: ReadonlyArray<ReadonlyArray<number>>;
+}
+
+export function checkConditionalIndependence<A>(
+  witness: MarkovConditionalWitness<A>,
+  options: ConditionalIndependenceOptions = {},
+): MarkovConditionalReport<A> {
+  const failures: ConditionalFailure[] = [];
+  const cardinality = productCardinality(witness.outputs);
+  if (cardinality !== witness.arrow.Y.elems.length) {
+    failures.push({
+      law: "cardinality",
+      message: `Codomain cardinality ${witness.arrow.Y.elems.length} mismatches product size ${cardinality}.`,
+    });
+  }
+
+  let factorized: FinMarkov<A, any>;
+  const components = conditionalMarginals(witness);
+  try {
+    factorized = factorizeConditional(witness);
+  } catch (error) {
+    failures.push({ law: "factorization", message: (error as Error).message });
+    // Fall back to an identity arrow to keep the report structurally consistent.
+    factorized = witness.arrow;
+  }
+
+  const equality = approxEqualMatrix(witness.arrow.matrix(), factorized.matrix());
+  if (!equality) {
+    failures.push({ law: "factorization", message: "Conditional kernel failed to equal its factorized reconstruction." });
+  }
+
+  const permutationReports: ConditionalPermutationReport[] = [];
+  for (const permutation of options.permutations ?? []) {
+    let holds = false;
+    let details: string;
+    try {
+      const perm = permutationKernel(witness.arrow.Y, witness.arity, permutation);
+      const permutedArrow = witness.arrow.then(perm);
+      const permutedFactor = factorized.then(perm);
+      holds = approxEqualMatrix(permutedArrow.matrix(), permutedFactor.matrix());
+      details = holds
+        ? "Permutation preserved conditional independence."
+        : "Permutation broke equality between arrow and factorization.";
+      if (!holds) {
+        failures.push({
+          law: "permutation",
+          message: `Permutation [${permutation.join(", ")}] violated conditional independence.`,
+          permutation,
+        });
+      }
+    } catch (error) {
+      details = (error as Error).message;
+      failures.push({
+        law: "permutation",
+        message: `Invalid permutation [${permutation.join(", ")}] — ${(error as Error).message}`,
+        permutation,
+      });
+    }
+    permutationReports.push({ permutation, holds, details });
+  }
+
+  const holds = failures.length === 0;
+  const descriptor = witness.label ?? `${witness.arity}-ary conditional kernel`;
+  const details = holds
+    ? `${descriptor} satisfies conditional independence.`
+    : `${descriptor} violated ${failures.length} condition${failures.length === 1 ? "" : "s"}.`;
+
+  return {
+    witness,
+    components,
+    factorized,
+    holds,
+    equality,
+    permutations: permutationReports,
+    failures,
+    details,
+  };
+}
+
+// ✅ END_MATH: MarkovConditionalIndependence
+// 🔮 Oracles: buildMarkovConditionalWitness, checkConditionalIndependence
+// 🧪 Tests: Covered in law.MarkovConditionalIndependence.spec.ts
+// 📊 Coverage: Finite Markov kernels with nested tensor products; extensible via custom projections for exotic codomains

--- a/markov-deterministic-structure.ts
+++ b/markov-deterministic-structure.ts
@@ -1,0 +1,564 @@
+// 🔮 BEGIN_MATH: MarkovDeterministicMorphism
+// 📝 Brief: Relate deterministic kernels with comonoid homomorphisms inside Markov categories.
+// 🏗️ Domain: Markov categories with designated copy/discard witnesses.
+// 🔗 Integration: Builds on MarkovComonoidWitness data and Markov-category utilities.
+// 📋 Plan:
+//   1. Provide deterministic morphism witnesses tied to source/target comonoid data.
+//   2. Extract deterministic base functions and compare against comonoid homomorphism checks.
+//   3. Emit rich oracle reports exposing determinism diagnostics and constructive witnesses.
+
+import type { Fin, Kernel, ComonoidHomReport, Pair } from "./markov-category";
+import { FinMarkov, checkComonoidHom, tensorObj, fst, snd, approxEqualMatrix } from "./markov-category";
+import { buildMarkovComonoidWitness } from "./markov-comonoid-structure";
+import type { MarkovComonoidWitness } from "./markov-comonoid-structure";
+import type {
+  DeterministicSetMultWitness,
+  DeterministicSetMultResult,
+  SetMulti,
+} from "./setmult-category";
+import {
+  isDeterministicSetMulti,
+  kernelToSetMulti,
+  setMultObjFromFin,
+  setMultiToDeterministic,
+} from "./setmult-category";
+import type { MarkovConditionalReport, MarkovConditionalWitness } from "./markov-conditional-independence";
+import { checkConditionalIndependence, conditionalMarginals } from "./markov-conditional-independence";
+
+export interface MarkovDeterministicWitness<X, Y> {
+  readonly domain: MarkovComonoidWitness<X>;
+  readonly codomain: MarkovComonoidWitness<Y>;
+  readonly arrow: FinMarkov<X, Y>;
+  readonly label?: string;
+  readonly base?: (x: X) => Y;
+}
+
+export interface MarkovPositivityWitness<B, C> {
+  readonly left: MarkovComonoidWitness<B>;
+  readonly right: MarkovComonoidWitness<C>;
+  readonly tensor: MarkovComonoidWitness<Pair<B, C>>;
+  readonly projectLeft: FinMarkov<Pair<B, C>, B>;
+  readonly projectRight: FinMarkov<Pair<B, C>, C>;
+  readonly label?: string;
+}
+
+export interface DeterminismCounterexample<X, Y> {
+  readonly input: X;
+  readonly distribution: Map<Y, number>;
+}
+
+export type DeterministicFailureLaw = "determinism" | "copy" | "discard" | "equivalence";
+
+export interface DeterministicFailure<X, Y> {
+  readonly law: DeterministicFailureLaw;
+  readonly message: string;
+  readonly counterexample?: DeterminismCounterexample<X, Y>;
+}
+
+export interface MarkovDeterminismReport<X, Y> extends ComonoidHomReport {
+  readonly holds: boolean;
+  readonly deterministic: boolean;
+  readonly comonoidHom: boolean;
+  readonly equivalent: boolean;
+  readonly witness: MarkovDeterministicWitness<X, Y>;
+  readonly base?: (x: X) => Y;
+  readonly details: string;
+  readonly failures: ReadonlyArray<DeterministicFailure<X, Y>>;
+}
+
+export interface MarkovDeterministicWitnessOptions<X, Y> {
+  readonly label?: string;
+  readonly base?: (x: X) => Y;
+}
+
+export interface MarkovPositivityWitnessOptions<B, C> {
+  readonly label?: string;
+  readonly tensor?: MarkovComonoidWitness<Pair<B, C>>;
+  readonly projectLeft?: FinMarkov<Pair<B, C>, B>;
+  readonly projectRight?: FinMarkov<Pair<B, C>, C>;
+}
+
+export interface TensorMarginalDeterminismReport<A, B, C> {
+  readonly holds: boolean;
+  readonly equivalent: boolean;
+  readonly tensor: MarkovDeterminismReport<A, Pair<B, C>>;
+  readonly left: MarkovDeterminismReport<A, B>;
+  readonly right: MarkovDeterminismReport<A, C>;
+  readonly witness: {
+    readonly domain: MarkovComonoidWitness<A>;
+    readonly positivity: MarkovPositivityWitness<B, C>;
+  };
+  readonly details: string;
+}
+
+function indexOfEq<T>(fin: Fin<T>, value: T): number {
+  const { elems, eq } = fin;
+  for (let i = 0; i < elems.length; i++) {
+    if (eq(elems[i], value)) return i;
+  }
+  return -1;
+}
+
+function describeObject<X>(witness: MarkovComonoidWitness<X>): string {
+  const size = witness.object.elems.length;
+  return witness.label ?? (size === 1 ? "terminal object" : `${size}-element object`);
+}
+
+function describeArrow<X, Y>(witness: MarkovDeterministicWitness<X, Y>): string {
+  if (witness.label) return witness.label;
+  const src = describeObject(witness.domain);
+  const tgt = describeObject(witness.codomain);
+  return `${src} → ${tgt}`;
+}
+
+function extractDeterministicBase<X, Y>(
+  domain: Fin<X>,
+  codomain: Fin<Y>,
+  kernel: Kernel<X, Y>,
+  tol = 1e-12,
+): { deterministic: true; base: (x: X) => Y } | { deterministic: false; counterexample: DeterminismCounterexample<X, Y> } {
+  const outputs: Y[] = [];
+  const { elems } = domain;
+  for (let i = 0; i < elems.length; i++) {
+    const x = elems[i];
+    const dist = kernel(x);
+    let support: Y | undefined;
+    let total = 0;
+    for (const [y, p] of dist) {
+      total += p;
+      if (p > tol) {
+        if (support === undefined) {
+          support = y;
+        } else if (!codomain.eq(support, y)) {
+          return { deterministic: false, counterexample: { input: x, distribution: dist } };
+        }
+      }
+    }
+    if (support === undefined || Math.abs(total - 1) > tol) {
+      return { deterministic: false, counterexample: { input: x, distribution: dist } };
+    }
+    outputs[i] = support;
+  }
+
+  const base = (x: X): Y => {
+    const idx = indexOfEq(domain, x);
+    if (idx < 0 || idx >= outputs.length) {
+      throw new Error("Input is outside the deterministic witness domain.");
+    }
+    return outputs[idx];
+  };
+  return { deterministic: true, base };
+}
+
+export function buildMarkovDeterministicWitness<X, Y>(
+  domain: MarkovComonoidWitness<X>,
+  codomain: MarkovComonoidWitness<Y>,
+  arrow: FinMarkov<X, Y>,
+  options: MarkovDeterministicWitnessOptions<X, Y> = {},
+): MarkovDeterministicWitness<X, Y> {
+  if (arrow.X !== domain.object) {
+    throw new Error("Deterministic witness domain does not match the provided comonoid witness.");
+  }
+  if (arrow.Y !== codomain.object) {
+    throw new Error("Deterministic witness codomain does not match the provided comonoid witness.");
+  }
+  return { domain, codomain, arrow, label: options.label, base: options.base };
+}
+
+export function buildMarkovPositivityWitness<B, C>(
+  left: MarkovComonoidWitness<B>,
+  right: MarkovComonoidWitness<C>,
+  options: MarkovPositivityWitnessOptions<B, C> = {},
+): MarkovPositivityWitness<B, C> {
+  const tensor = options.tensor ??
+    buildMarkovComonoidWitness(tensorObj(left.object, right.object), { label: options.label });
+
+  const defaultProjectLeft = new FinMarkov(tensor.object, left.object, fst<B, C>());
+  const defaultProjectRight = new FinMarkov(tensor.object, right.object, snd<B, C>());
+
+  const projectLeft = options.projectLeft ?? defaultProjectLeft;
+  const projectRight = options.projectRight ?? defaultProjectRight;
+
+  if (projectLeft.X !== tensor.object || projectRight.X !== tensor.object) {
+    throw new Error("Positivity projections must originate from the tensor object.");
+  }
+  if (projectLeft.Y !== left.object) {
+    throw new Error("Left projection does not land in the left witness object.");
+  }
+  if (projectRight.Y !== right.object) {
+    throw new Error("Right projection does not land in the right witness object.");
+  }
+
+  return { left, right, tensor, projectLeft, projectRight, label: options.label };
+}
+
+export function checkDeterministicComonoid<X, Y>(
+  witness: MarkovDeterministicWitness<X, Y>,
+): MarkovDeterminismReport<X, Y> {
+  const { domain, codomain, arrow } = witness;
+  const descriptor = describeArrow(witness);
+
+  const detResult = extractDeterministicBase(domain.object, codomain.object, arrow.k);
+  const deterministic = detResult.deterministic;
+  const base = deterministic ? detResult.base : undefined;
+
+  const hom = checkComonoidHom(domain.object, codomain.object, arrow.k);
+  const comonoidHom = hom.preservesCopy && hom.preservesDiscard;
+  const equivalent = deterministic === comonoidHom;
+  const holds = deterministic && comonoidHom;
+
+  const failures: DeterministicFailure<X, Y>[] = [];
+
+  if (!deterministic) {
+    const counterexample = (detResult as { counterexample?: DeterminismCounterexample<X, Y> }).counterexample;
+    failures.push({
+      law: "determinism",
+      message: `Kernel ${descriptor} is not deterministic: found a non-Dirac output.`,
+      counterexample,
+    });
+  }
+  if (!hom.preservesCopy) {
+    failures.push({ law: "copy", message: `Copy law failed for ${descriptor}.` });
+  }
+  if (!hom.preservesDiscard) {
+    failures.push({ law: "discard", message: `Discard law failed for ${descriptor}.` });
+  }
+  if (!equivalent) {
+    failures.push({ law: "equivalence", message: `Determinism and comonoid homomorphism disagreed for ${descriptor}.` });
+  }
+
+  const details = holds
+    ? `Morphism ${descriptor} is deterministic and preserves copy/discard.`
+    : `${failures.length} determinism check${failures.length === 1 ? "" : "s"} failed for ${descriptor}.`;
+
+  return {
+    ...hom,
+    holds,
+    deterministic,
+    comonoidHom,
+    equivalent,
+    witness,
+    base,
+    details,
+    failures,
+  };
+}
+
+export function certifyDeterministicFunction<X, Y>(
+  domain: MarkovComonoidWitness<X>,
+  codomain: MarkovComonoidWitness<Y>,
+  base: (x: X) => Y,
+  options: MarkovDeterministicWitnessOptions<X, Y> = {},
+): MarkovDeterministicWitness<X, Y> {
+  const arrow = new FinMarkov(domain.object, codomain.object, (x: X) => new Map([[base(x), 1]]));
+  return buildMarkovDeterministicWitness(domain, codomain, arrow, { ...options, base });
+}
+
+export function checkDeterministicTensorViaMarginals<A, B, C>(
+  domain: MarkovComonoidWitness<A>,
+  positivity: MarkovPositivityWitness<B, C>,
+  arrow: FinMarkov<A, Pair<B, C>>,
+  options: MarkovDeterministicWitnessOptions<A, Pair<B, C>> = {},
+): TensorMarginalDeterminismReport<A, B, C> {
+  if (arrow.Y !== positivity.tensor.object) {
+    throw new Error("Tensor arrow codomain does not match the positivity witness tensor object.");
+  }
+
+  const tensorWitness = buildMarkovDeterministicWitness(domain, positivity.tensor, arrow, options);
+  const tensorReport = checkDeterministicComonoid(tensorWitness);
+
+  const leftArrow = arrow.then(positivity.projectLeft);
+  const rightArrow = arrow.then(positivity.projectRight);
+
+  const leftWitness = buildMarkovDeterministicWitness(domain, positivity.left, leftArrow);
+  const rightWitness = buildMarkovDeterministicWitness(domain, positivity.right, rightArrow);
+
+  const leftReport = checkDeterministicComonoid(leftWitness);
+  const rightReport = checkDeterministicComonoid(rightWitness);
+
+  const marginalsDeterministic = leftReport.deterministic && rightReport.deterministic;
+  const equivalent = tensorReport.deterministic === marginalsDeterministic;
+  const holds = equivalent;
+
+  const descriptor = tensorWitness.label ?? positivity.label ?? "tensor morphism";
+  const details = holds
+    ? `Determinism of ${descriptor} matches the determinism of both marginals.`
+    : `Determinism of ${descriptor} disagrees with its marginals.`;
+
+  return {
+    holds,
+    equivalent,
+    tensor: tensorReport,
+    left: leftReport,
+    right: rightReport,
+    witness: { domain, positivity },
+    details,
+  };
+}
+
+export interface DeterminismLemmaWitness<A, X, T> {
+  readonly conditional: MarkovConditionalWitness<A>;
+  readonly p: FinMarkov<A, X>;
+  readonly deterministic: MarkovDeterministicWitness<X, T>;
+  readonly xIndex?: number;
+  readonly tIndex?: number;
+  readonly label?: string;
+}
+
+export interface DeterminismLemmaOptions<A> {
+  readonly permutations?: ReadonlyArray<ReadonlyArray<number>>;
+  readonly tolerance?: number;
+  readonly conditionalReport?: MarkovConditionalReport<A>;
+}
+
+export type DeterminismLemmaFailureLaw =
+  | "conditionalIndependence"
+  | "deterministicComponent"
+  | "marginalMismatch"
+  | "compositeDeterminism";
+
+export interface DeterminismLemmaFailure {
+  readonly law: DeterminismLemmaFailureLaw;
+  readonly message: string;
+}
+
+export interface DeterminismLemmaReport<A, X, T> {
+  readonly holds: boolean;
+  readonly witness: {
+    readonly conditional: MarkovConditionalWitness<A>;
+    readonly p: FinMarkov<A, X>;
+    readonly deterministic: MarkovDeterministicWitness<X, T>;
+    readonly xIndex: number;
+    readonly tIndex: number;
+  };
+  readonly conditional: MarkovConditionalReport<A>;
+  readonly deterministic: MarkovDeterminismReport<X, T>;
+  readonly composite: MarkovDeterminismReport<A, T>;
+  readonly marginals: {
+    readonly x: FinMarkov<A, X>;
+    readonly t: FinMarkov<A, T>;
+  };
+  readonly compositeArrow: FinMarkov<A, T>;
+  readonly failures: ReadonlyArray<DeterminismLemmaFailure>;
+  readonly details: string;
+}
+
+export function checkDeterminismLemma<A, X, T>(
+  witness: DeterminismLemmaWitness<A, X, T>,
+  options: DeterminismLemmaOptions<A> = {},
+): DeterminismLemmaReport<A, X, T> {
+  const { conditional, p, deterministic } = witness;
+  const xIndex = witness.xIndex ?? 0;
+  const tIndex = witness.tIndex ?? 1;
+
+  if (xIndex === tIndex) {
+    throw new Error("Determinism lemma requires distinct indices for X and T marginals.");
+  }
+
+  if (xIndex < 0 || xIndex >= conditional.outputs.length) {
+    throw new Error(`X marginal index ${xIndex} is outside the conditional witness outputs.`);
+  }
+  if (tIndex < 0 || tIndex >= conditional.outputs.length) {
+    throw new Error(`T marginal index ${tIndex} is outside the conditional witness outputs.`);
+  }
+
+  if (p.X !== conditional.domain.object) {
+    throw new Error("Kernel p must share the conditional witness domain.");
+  }
+
+  const xWitness = conditional.outputs[xIndex];
+  const tWitness = conditional.outputs[tIndex];
+
+  if (p.Y !== xWitness.object) {
+    throw new Error("Kernel p must land in the X output of the conditional witness.");
+  }
+  if (deterministic.domain.object !== xWitness.object) {
+    throw new Error("Deterministic arrow s must consume the X output object.");
+  }
+  if (deterministic.codomain.object !== tWitness.object) {
+    throw new Error("Deterministic arrow s must land in the T output object.");
+  }
+
+  const tol = options.tolerance ?? 1e-9;
+  const components = conditionalMarginals(conditional);
+  const xMarginal = components[xIndex] as FinMarkov<A, X>;
+  const tMarginal = components[tIndex] as FinMarkov<A, T>;
+
+  const conditionalReport =
+    options.conditionalReport ??
+    checkConditionalIndependence(conditional, options.permutations ? { permutations: options.permutations } : {});
+
+  const deterministicReport = checkDeterministicComonoid(deterministic);
+
+  const compositeArrow = p.then(deterministic.arrow);
+  const compositeLabel = witness.label ? `${witness.label} composite` : undefined;
+  const compositeWitness = buildMarkovDeterministicWitness(
+    conditional.domain,
+    deterministic.codomain,
+    compositeArrow,
+    { label: compositeLabel },
+  );
+  const compositeReport = checkDeterministicComonoid(compositeWitness);
+
+  const failures: DeterminismLemmaFailure[] = [];
+
+  const xMatches = approxEqualMatrix(xMarginal.matrix(), p.matrix(), tol);
+  if (!xMatches) {
+    failures.push({
+      law: "marginalMismatch",
+      message: "Conditional witness first marginal does not match the provided kernel p.",
+    });
+  }
+
+  const tMatches = approxEqualMatrix(tMarginal.matrix(), compositeArrow.matrix(), tol);
+  if (!tMatches) {
+    failures.push({
+      law: "marginalMismatch",
+      message: "Conditional witness T marginal does not match the composite s ∘ p.",
+    });
+  }
+
+  if (!deterministicReport.holds) {
+    failures.push({
+      law: "deterministicComponent",
+      message: deterministicReport.details,
+    });
+  }
+
+  if (!conditionalReport.holds) {
+    failures.push({
+      law: "conditionalIndependence",
+      message: conditionalReport.details,
+    });
+  }
+
+  if (!compositeReport.deterministic) {
+    failures.push({
+      law: "compositeDeterminism",
+      message: compositeReport.details,
+    });
+  }
+
+  const holds =
+    failures.length === 0 &&
+    conditionalReport.holds &&
+    deterministicReport.deterministic &&
+    compositeReport.deterministic;
+
+  const compositeDescriptor = describeArrow(compositeWitness);
+  const descriptor = witness.label ?? "determinism lemma";
+  const details = holds
+    ? `${descriptor}: composite ${compositeDescriptor} is deterministic under the conditional independence hypothesis.`
+    : `${descriptor}: detected ${failures.length} issue${failures.length === 1 ? "" : "s"} while applying the determinism lemma.`;
+
+  return {
+    holds,
+    witness: { conditional, p, deterministic, xIndex, tIndex },
+    conditional: conditionalReport,
+    deterministic: deterministicReport,
+    composite: compositeReport,
+    marginals: { x: xMarginal, t: tMarginal },
+    compositeArrow,
+    failures,
+    details,
+  };
+}
+
+const equalSet = <T>(eq: (a: T, b: T) => boolean, left: ReadonlySet<T>, right: ReadonlySet<T>): boolean => {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    let found = false;
+    for (const candidate of right) {
+      if (eq(candidate, value)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+};
+
+export interface SetMultDeterminismOptions<X, Y> {
+  readonly label?: string;
+  readonly arrow?: FinMarkov<X, Y>;
+}
+
+export interface SetMultDeterminismWitness<X, Y> {
+  readonly domain: Fin<X>;
+  readonly codomain: Fin<Y>;
+  readonly morphism: SetMulti<X, Y>;
+  readonly setWitness: DeterministicSetMultWitness<X, Y>;
+  readonly arrow?: FinMarkov<X, Y>;
+  readonly label?: string;
+}
+
+export interface SetMultDeterminismReport<X, Y> {
+  readonly holds: boolean;
+  readonly deterministic: DeterministicSetMultResult<X, Y>;
+  readonly matchesKernel: boolean;
+  readonly witness: SetMultDeterminismWitness<X, Y>;
+  readonly base?: (a: X) => Y;
+  readonly mismatches: ReadonlyArray<{ readonly input: X; readonly setMult: ReadonlySet<Y>; readonly kernel: ReadonlySet<Y> }>;
+  readonly details: string;
+}
+
+export function buildSetMultDeterminismWitness<X, Y>(
+  domain: Fin<X>,
+  codomain: Fin<Y>,
+  morphism: SetMulti<X, Y>,
+  options: SetMultDeterminismOptions<X, Y> = {},
+): SetMultDeterminismWitness<X, Y> {
+  const setWitness: DeterministicSetMultWitness<X, Y> = {
+    domain: setMultObjFromFin(domain, options.label ? `${options.label} domain` : undefined),
+    codomain: setMultObjFromFin(codomain, options.label ? `${options.label} codomain` : undefined),
+    morphism,
+    label: options.label,
+  };
+  return { domain, codomain, morphism, setWitness, arrow: options.arrow, label: options.label };
+}
+
+export function checkSetMultDeterminism<X, Y>(
+  witness: SetMultDeterminismWitness<X, Y>,
+): SetMultDeterminismReport<X, Y> {
+  const deterministic = isDeterministicSetMulti(witness.setWitness, { samples: witness.domain.elems });
+  const mismatches: Array<{ input: X; setMult: ReadonlySet<Y>; kernel: ReadonlySet<Y> }> = [];
+  let matchesKernel = true;
+
+  if (witness.arrow) {
+    const kernelMulti = kernelToSetMulti(witness.codomain, witness.arrow.k);
+    const eq = witness.setWitness.codomain.eq;
+    for (const input of witness.domain.elems) {
+      const setMultFibre = witness.morphism(input);
+      const kernelFibre = kernelMulti(input);
+      if (!equalSet(eq, setMultFibre, kernelFibre)) {
+        matchesKernel = false;
+        mismatches.push({ input, setMult: setMultFibre, kernel: kernelFibre });
+      }
+    }
+  }
+
+  const holds = deterministic.deterministic && matchesKernel;
+  const details = holds
+    ? "SetMult morphism is deterministic and matches the kernel support"
+    : matchesKernel
+    ? "SetMult morphism is not deterministic"
+    : deterministic.deterministic
+    ? "SetMult morphism disagrees with the kernel support"
+    : "SetMult morphism failed determinism and kernel compatibility";
+
+  return {
+    holds,
+    deterministic,
+    matchesKernel,
+    witness,
+    base: deterministic.deterministic ? deterministic.base : undefined,
+    mismatches,
+    details,
+  };
+}
+
+// ✅ END_MATH: MarkovDeterministicMorphism
+// 🔮 Oracles: checkDeterministicComonoid, checkDeterministicTensorViaMarginals, checkDeterminismLemma, checkSetMultDeterminism
+// 🧪 Tests: law.MarkovCategory.spec.ts deterministic/comonoid suite
+// 📊 Coverage: Finite Markov kernels; extendable to inverse-limit carriers via projective witnesses

--- a/markov-infinite-oracles.ts
+++ b/markov-infinite-oracles.ts
@@ -1,0 +1,1191 @@
+import type { Dist } from "./dist";
+import { bind, map } from "./dist";
+import type { CSRig } from "./semiring-utils";
+import { FinMarkov, tensorObj, pair, IFin } from "./markov-category";
+import type {
+  CountabilityWitness,
+  InfObj,
+  KernelR,
+  CylinderSection,
+  FiniteSubset,
+  ProjectiveFamily,
+  MeasurabilityWitness,
+  DeterministicKolmogorovProductWitness,
+  PositivityWitness,
+  DeterministicKolmogorovFactorization,
+  DeterministicComponent,
+  DeterministicKolmogorovFactorizationFailure,
+  DeterministicProductComponentInput,
+  DeterministicMediatorCandidate,
+  KolmogorovZeroOneLawWitness,
+  HewittSavageZeroOneLawWitness,
+} from "./markov-infinite";
+import {
+  applyPatch,
+  checkKolmogorovConsistency,
+  deterministicBooleanValue,
+  equalDist,
+  isCountableIndex,
+  hasMeasurabilityWitness,
+  isStandardBorelFamily,
+  kolmogorovExtensionMeasure,
+} from "./markov-infinite";
+import {
+  buildMarkovComonoidWitness,
+  type MarkovComonoidWitness,
+} from "./markov-comonoid-structure";
+import {
+  buildMarkovPositivityWitness,
+  checkDeterministicTensorViaMarginals,
+  checkDeterminismLemma,
+  type TensorMarginalDeterminismReport,
+  type DeterminismLemmaReport,
+  type DeterminismLemmaOptions,
+} from "./markov-deterministic-structure";
+import {
+  checkConditionalIndependence,
+  type MarkovConditionalReport,
+} from "./markov-conditional-independence";
+
+const sectionsEqual = <J, X>(
+  left: CylinderSection<J, X>,
+  right: CylinderSection<J, X>
+): boolean => {
+  if (left.size !== right.size) return false;
+  for (const [key, value] of left) {
+    if (!right.has(key)) return false;
+    if (right.get(key) !== value) return false;
+  }
+  return true;
+};
+
+const aggregateCylinderDist = <R, J, X>(
+  R: CSRig<R>,
+  dist: Dist<R, CylinderSection<J, X>>
+): Dist<R, CylinderSection<J, X>> => {
+  const entries: Array<{ section: CylinderSection<J, X>; weight: R }> = [];
+  dist.w.forEach((weight, section) => {
+    const existing = entries.find((candidate) => sectionsEqual(candidate.section, section));
+    if (existing) {
+      existing.weight = R.add(existing.weight, weight);
+    } else {
+      entries.push({ section, weight });
+    }
+  });
+
+  const merged: Dist<R, CylinderSection<J, X>> = { R, w: new Map() };
+  for (const entry of entries) {
+    merged.w.set(entry.section, entry.weight);
+  }
+  return merged;
+};
+
+const defaultIsZero = <R>(R: CSRig<R>) => R.isZero ?? ((a: R) => R.eq(a, R.zero));
+
+const terminalComonoidWitness = buildMarkovComonoidWitness(IFin, { label: "tensor unit" });
+
+const describeSubset = <J>(subset: FiniteSubset<J>): string =>
+  subset.length === 0 ? "∅" : subset.map((index) => String(index)).join(", ");
+
+export interface TailInvarianceResult<J, Carrier> {
+  readonly ok: boolean;
+  readonly counterexamples: Array<{ original: Carrier; modified: Carrier }>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function checkTailEventInvariance<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  tailEvent: KernelR<R, Carrier, boolean>,
+  samples: ReadonlyArray<Carrier>,
+  patches: ReadonlyArray<CylinderSection<J, X>>
+): TailInvarianceResult<J, Carrier> {
+  const counterexamples: Array<{ original: Carrier; modified: Carrier }> = [];
+  const { family } = obj;
+  const R = family.semiring;
+
+  for (const sample of samples) {
+    const base = deterministicBooleanValue(R, tailEvent(sample));
+    for (const patch of patches) {
+      const modified = applyPatch(family, sample, patch);
+      const value = deterministicBooleanValue(R, tailEvent(modified));
+      if (value !== base) {
+        counterexamples.push({ original: sample, modified });
+      }
+    }
+  }
+
+  return {
+    ok: counterexamples.length === 0,
+    counterexamples,
+    countable: isCountableIndex(family),
+    witness: family.countability,
+    measurable: hasMeasurabilityWitness(family),
+    measurability: family.measurability,
+    standardBorel: isStandardBorelFamily(family),
+  };
+}
+
+export interface KolmogorovConsistencyResult<J> {
+  readonly ok: boolean;
+  readonly failures: ReadonlyArray<{ finite: FiniteSubset<J>; larger: FiniteSubset<J> }>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function runKolmogorovConsistency<R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>,
+  tests: ReadonlyArray<{ finite: FiniteSubset<J>; larger: FiniteSubset<J> }>
+): KolmogorovConsistencyResult<J> {
+  const { ok, failures, countable, witness, measurable, measurability, standardBorel } =
+    checkKolmogorovConsistency(family, tests);
+  return { ok, failures, countable, witness, measurable, measurability, standardBorel };
+}
+
+export interface ZeroOneWitness<R, J> {
+  readonly ok: boolean;
+  readonly probability: R;
+  readonly support: Dist<R, boolean>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export interface TailSigmaSectionReport<R, J, X> {
+  readonly section: CylinderSection<J, X>;
+  readonly probability: R;
+  readonly tailAndSection: R;
+  readonly product: R;
+  readonly ok: boolean;
+}
+
+export interface TailSigmaSubsetReport<R, J, X> {
+  readonly subset: FiniteSubset<J>;
+  readonly ok: boolean;
+  readonly tailProbability: R;
+  readonly sections: ReadonlyArray<TailSigmaSectionReport<R, J, X>>;
+  readonly errors: ReadonlyArray<string>;
+}
+
+export interface TailSigmaIndependenceResult<R, J, X> {
+  readonly ok: boolean;
+  readonly tailProbability: R;
+  readonly subsets: ReadonlyArray<TailSigmaSubsetReport<R, J, X>>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+const getOrCreateSectionReport = <R, J, X>(
+  R: CSRig<R>,
+  sections: Array<{ section: CylinderSection<J, X>; probability: R; tailAndSection: R }>,
+  section: CylinderSection<J, X>
+) => {
+  const existing = sections.find((candidate) => sectionsEqual(candidate.section, section));
+  if (existing) return existing;
+  const fresh = {
+    section,
+    probability: R.zero,
+    tailAndSection: R.zero,
+  };
+  sections.push(fresh);
+  return fresh;
+};
+
+export function checkTailSigmaIndependence<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  measure: Dist<R, Carrier>,
+  tailEvent: KernelR<R, Carrier, boolean>,
+  subsets: ReadonlyArray<FiniteSubset<J>>
+): TailSigmaIndependenceResult<R, J, X> {
+  const R = obj.family.semiring;
+  if (measure.R !== R) {
+    throw new Error("Measure semiring does not match projective family semiring");
+  }
+
+  const isZero = defaultIsZero(R);
+  const support = bind(measure, tailEvent);
+  const tailProbability = support.w.get(true) ?? R.zero;
+
+  const subsetReports = subsets.map((subset) => {
+    const sectionReports: Array<{ section: CylinderSection<J, X>; probability: R; tailAndSection: R }> = [];
+    const errors: string[] = [];
+
+    measure.w.forEach((weight, carrier) => {
+      if (isZero(weight)) return;
+
+      let tailValue: boolean;
+      try {
+        tailValue = deterministicBooleanValue(R, tailEvent(carrier));
+      } catch (error) {
+        errors.push(
+          `Tail event not deterministic on subset {${describeSubset(subset)}}: ${(error as Error).message}`
+        );
+        return;
+      }
+
+      const projection = aggregateCylinderDist(R, obj.projectKernel(subset)(carrier));
+      let sawSupport = false;
+      projection.w.forEach((sectionWeight, section) => {
+        if (isZero(sectionWeight)) return;
+        sawSupport = true;
+        const entry = getOrCreateSectionReport(R, sectionReports, section);
+        const contribution = R.mul(weight, sectionWeight);
+        entry.probability = R.add(entry.probability, contribution);
+        if (tailValue) {
+          entry.tailAndSection = R.add(entry.tailAndSection, contribution);
+        }
+      });
+
+      if (!sawSupport) {
+        errors.push(`Projection onto subset {${describeSubset(subset)}} returned zero support.`);
+      }
+    });
+
+    const sections: TailSigmaSectionReport<R, J, X>[] = sectionReports.map((entry) => {
+      const product = R.mul(tailProbability, entry.probability);
+      return {
+        section: entry.section,
+        probability: entry.probability,
+        tailAndSection: entry.tailAndSection,
+        product,
+        ok: R.eq(entry.tailAndSection, product),
+      };
+    });
+
+    const subsetOk = errors.length === 0 && sections.every((section) => section.ok);
+    return {
+      subset,
+      ok: subsetOk,
+      tailProbability,
+      sections,
+      errors,
+    };
+  });
+
+  return {
+    ok: subsetReports.every((report) => report.ok),
+    tailProbability,
+    subsets: subsetReports,
+    countable: isCountableIndex(obj.family),
+    witness: obj.family.countability,
+    measurable: hasMeasurabilityWitness(obj.family),
+    measurability: obj.family.measurability,
+    standardBorel: isStandardBorelFamily(obj.family),
+  };
+}
+
+export function kolmogorovZeroOneWitness<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  measure: Dist<R, Carrier>,
+  tailEvent: KernelR<R, Carrier, boolean>
+): ZeroOneWitness<R, J> {
+  const R = obj.family.semiring;
+  if (measure.R !== R) {
+    throw new Error("Measure semiring does not match projective family semiring");
+  }
+
+  const pushed = bind(measure, tailEvent);
+  const probTrue = pushed.w.get(true) ?? R.zero;
+  const probFalse = pushed.w.get(false) ?? R.zero;
+  const isZero = defaultIsZero(R);
+  const zeroOrOne = R.eq(probTrue, R.one) || isZero(probTrue) || R.eq(probFalse, R.one) || isZero(probFalse);
+
+  return {
+    ok: zeroOrOne,
+    probability: probTrue,
+    support: pushed,
+    countable: isCountableIndex(obj.family),
+    witness: obj.family.countability,
+    measurable: hasMeasurabilityWitness(obj.family),
+    measurability: obj.family.measurability,
+    standardBorel: isStandardBorelFamily(obj.family),
+  };
+}
+
+export interface KolmogorovZeroOneLawOptions<A, J> {
+  readonly subsets?: ReadonlyArray<FiniteSubset<J>>;
+  readonly samples?: ReadonlyArray<A>;
+  readonly independencePermutations?: ReadonlyArray<ReadonlyArray<number>>;
+  readonly tailConditionalPermutations?: ReadonlyArray<ReadonlyArray<number>>;
+  readonly lemma?: DeterminismLemmaOptions<A>;
+  readonly universalSubset?: FiniteSubset<J>;
+  readonly partitions?: ReadonlyArray<FiniteSubset<J>>;
+  readonly candidateLabel?: string;
+}
+
+export interface KolmogorovZeroOneLawResult<R, A, J, X, Carrier, XDet, Tail> {
+  readonly ok: boolean;
+  readonly zeroOne: ZeroOneWitness<R, J>;
+  readonly tail: TailSigmaIndependenceResult<R, J, X>;
+  readonly independence?: MarkovConditionalReport<A>;
+  readonly tailConditional?: MarkovConditionalReport<A>;
+  readonly determinism?: DeterminismLemmaReport<A, XDet, Tail>;
+  readonly universal?: DeterministicProductUniversalPropertyResult<R, A, J, X, Carrier>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function checkKolmogorovZeroOneLaw<R, A, J, X, Carrier, XDet = unknown, Tail = unknown>(
+  witness: KolmogorovZeroOneLawWitness<R, A, J, X, Carrier, XDet, Tail>,
+  options: KolmogorovZeroOneLawOptions<A, J> = {},
+): KolmogorovZeroOneLawResult<R, A, J, X, Carrier, XDet, Tail> {
+  const subsets = options.subsets ?? [];
+  const tail = checkTailSigmaIndependence(witness.product.infObj, witness.measure, witness.tailEvent, subsets);
+  const zeroOne = kolmogorovZeroOneWitness(witness.product.infObj, witness.measure, witness.tailEvent);
+
+  const independence = witness.independence
+    ? checkConditionalIndependence(
+        witness.independence,
+        options.independencePermutations ? { permutations: options.independencePermutations } : {},
+      )
+    : undefined;
+
+  const tailConditional = witness.tailConditional
+    ? checkConditionalIndependence(
+        witness.tailConditional,
+        options.tailConditionalPermutations ? { permutations: options.tailConditionalPermutations } : {},
+      )
+    : undefined;
+
+  const determinism = witness.determinismLemma
+    ? checkDeterminismLemma(witness.determinismLemma, options.lemma)
+    : undefined;
+
+  let universal: DeterministicProductUniversalPropertyResult<R, A, J, X, Carrier> | undefined;
+  const components = witness.components ?? [];
+  if (witness.mediator && components.length > 0) {
+    const inferredSubset = components.map((component) => component.index) as FiniteSubset<J>;
+    const subset = options.universalSubset ?? (inferredSubset.length > 0 ? inferredSubset : subsets[0] ?? ([] as FiniteSubset<J>));
+    universal = checkDeterministicProductUniversalProperty(witness.product, witness.mediator, subset, {
+      domain: witness.domain,
+      components,
+      samples: options.samples ?? witness.domain.object.elems,
+      partitions: options.partitions,
+      label: options.candidateLabel,
+    });
+  }
+
+  const ok =
+    tail.ok &&
+    zeroOne.ok &&
+    (independence?.holds ?? true) &&
+    (tailConditional?.holds ?? true) &&
+    (determinism?.holds ?? true) &&
+    (universal?.ok ?? true);
+
+  return {
+    ok,
+    zeroOne,
+    tail,
+    independence,
+    tailConditional,
+    determinism,
+    universal,
+    countable: tail.countable,
+    witness: tail.witness,
+    measurable: tail.measurable,
+    measurability: tail.measurability,
+    standardBorel: tail.standardBorel,
+  };
+}
+
+export interface ExchangeabilityResult<R, J, Carrier> {
+  readonly ok: boolean;
+  readonly exchangeable: boolean;
+  readonly invariant: boolean;
+  readonly probability: R;
+  readonly support: Dist<R, boolean>;
+  readonly counterexamples: Array<{ original: Carrier; permuted: Carrier }>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export type HewittSavageZeroOneLawOptions<A, J> = KolmogorovZeroOneLawOptions<A, J>;
+
+export interface HewittSavageZeroOneLawResult<R, A, J, X, Carrier, XDet, Tail>
+  extends KolmogorovZeroOneLawResult<R, A, J, X, Carrier, XDet, Tail> {
+  readonly exchangeability: ExchangeabilityResult<R, J, Carrier>;
+}
+
+export function checkHewittSavageZeroOneLaw<R, A, J, X, Carrier, XDet = unknown, Tail = unknown>(
+  witness: HewittSavageZeroOneLawWitness<R, A, J, X, Carrier, XDet, Tail>,
+  options: HewittSavageZeroOneLawOptions<A, J> = {},
+): HewittSavageZeroOneLawResult<R, A, J, X, Carrier, XDet, Tail> {
+  const base = checkKolmogorovZeroOneLaw<R, A, J, X, Carrier, XDet, Tail>(witness, options);
+  const exchangeability = hewittSavageZeroOneWitness(
+    witness.product.infObj,
+    witness.measure,
+    witness.tailEvent,
+    witness.permutations,
+  );
+  const ok = base.ok && exchangeability.ok;
+  return { ...base, ok, exchangeability };
+}
+
+export interface FiniteReductionResult<R, J, X> {
+  readonly ok: boolean;
+  readonly expected: Dist<R, CylinderSection<J, X>>;
+  readonly actual: Dist<R, CylinderSection<J, X>>;
+}
+
+export function checkFiniteProductReduction<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  measure: Dist<R, Carrier>,
+  subset: FiniteSubset<J>
+): FiniteReductionResult<R, J, X> {
+  const R = obj.family.semiring;
+  if (measure.R !== R) {
+    throw new Error("Measure semiring does not match projective family semiring");
+  }
+
+  const expectedRaw = obj.family.marginal(subset);
+  const actualRaw = bind(measure, obj.projectKernel(subset));
+  const expected = aggregateCylinderDist(R, expectedRaw);
+  const actual = aggregateCylinderDist(R, actualRaw);
+  const ok = equalDist(R, expected, actual);
+
+  return { ok, expected, actual };
+}
+
+export interface CopyDiscardFailure<R, J, X, Carrier> {
+  readonly sample: Carrier;
+  readonly subset: FiniteSubset<J>;
+  readonly direct: Dist<R, CylinderSection<J, X>>;
+  readonly viaCopy: Dist<R, CylinderSection<J, X>>;
+}
+
+export interface CopyDiscardCompatibilityResult<R, J, X, Carrier> {
+  readonly ok: boolean;
+  readonly failures: ReadonlyArray<CopyDiscardFailure<R, J, X, Carrier>>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function checkCopyDiscardCompatibility<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  subsets: ReadonlyArray<FiniteSubset<J>>,
+  samples: ReadonlyArray<Carrier>
+): CopyDiscardCompatibilityResult<R, J, X, Carrier> {
+  const failures: Array<CopyDiscardFailure<R, J, X, Carrier>> = [];
+  const R = obj.family.semiring;
+
+  for (const sample of samples) {
+    for (const subset of subsets) {
+      const direct = obj.projectKernel(subset)(sample);
+      const viaCopy = bind(obj.copy(sample), ([left, right]) =>
+        bind(obj.discard(left), () => obj.projectKernel(subset)(right))
+      );
+
+      if (!equalDist(R, direct, viaCopy)) {
+        failures.push({ sample, subset, direct, viaCopy });
+      }
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    countable: isCountableIndex(obj.family),
+    witness: obj.family.countability,
+    measurable: hasMeasurabilityWitness(obj.family),
+    measurability: obj.family.measurability,
+    standardBorel: isStandardBorelFamily(obj.family),
+  };
+}
+
+export interface DeterministicComponentDeterminismReport<A, J, X> {
+  readonly index: J;
+  readonly label?: string;
+  readonly report: TensorMarginalDeterminismReport<A, X, {}>;
+  readonly ok: boolean;
+}
+
+export interface DeterministicMediatorMismatch<A, J, X, Carrier> {
+  readonly input: A;
+  readonly subset: FiniteSubset<J>;
+  readonly expected: { carrier: Carrier; section: CylinderSection<J, X> };
+  readonly actual: { carrier: Carrier; section: CylinderSection<J, X> };
+}
+
+export interface DeterministicProductPartitionReport<R, A, J, X, Carrier> {
+  readonly subset: FiniteSubset<J>;
+  readonly factorization: DeterministicKolmogorovFactorization<R, A, J, X, Carrier>;
+  readonly mismatches: ReadonlyArray<DeterministicMediatorMismatch<A, J, X, Carrier>>;
+  readonly ok: boolean;
+  readonly details: string;
+}
+
+export interface DeterministicProductUniversalPropertyOptions<R, A, J, X, Carrier> {
+  readonly domain: MarkovComonoidWitness<A>;
+  readonly components: ReadonlyArray<DeterministicProductComponentInput<A, J, X>>;
+  readonly samples?: ReadonlyArray<A>;
+  readonly alternate?: DeterministicMediatorCandidate<R, A, Carrier>;
+  readonly partitions?: ReadonlyArray<FiniteSubset<J>>;
+  readonly label?: string;
+}
+
+export interface DeterministicProductUniversalPropertyResult<R, A, J, X, Carrier> {
+  readonly ok: boolean;
+  readonly subset: FiniteSubset<J>;
+  readonly components: ReadonlyArray<DeterministicComponentDeterminismReport<A, J, X>>;
+  readonly factorization: DeterministicKolmogorovFactorization<R, A, J, X, Carrier>;
+  readonly mediatorAgreement: boolean;
+  readonly mismatches: ReadonlyArray<DeterministicMediatorMismatch<A, J, X, Carrier>>;
+  readonly uniqueness?: {
+    readonly ok: boolean;
+    readonly mismatches: ReadonlyArray<DeterministicMediatorMismatch<A, J, X, Carrier>>;
+    readonly label?: string;
+  };
+  readonly partitions?: ReadonlyArray<DeterministicProductPartitionReport<R, A, J, X, Carrier>>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+  readonly positive: boolean;
+  readonly positivity?: PositivityWitness<J>;
+  readonly details: string;
+  readonly candidateLabel?: string;
+}
+
+const ensureDeterministicBase = <A, X>(
+  arrow: FinMarkov<A, X>,
+  label: string
+): ((input: A) => X) => {
+  const EPS = 1e-9;
+  return (input: A) => {
+    const dist = arrow.k(input);
+    let value: X | undefined;
+    dist.forEach((weight, outcome) => {
+      if (weight > EPS) {
+        if (value !== undefined && value !== outcome) {
+          throw new Error(
+            `Deterministic base extraction for ${label} found multiple outcomes with weight > ${EPS}.`
+          );
+        }
+        value = outcome;
+      }
+    });
+    if (value === undefined) {
+      const entries = Array.from(dist.keys());
+      if (entries.length === 1) {
+        return entries[0];
+      }
+      throw new Error(`Deterministic base extraction for ${label} produced no support.`);
+    }
+    return value;
+  };
+};
+
+export function checkDeterministicProductUniversalProperty<R, A, J, X, Carrier>(
+  witness: DeterministicKolmogorovProductWitness<R, J, X, Carrier>,
+  candidate: DeterministicMediatorCandidate<R, A, Carrier>,
+  subset: FiniteSubset<J>,
+  options: DeterministicProductUniversalPropertyOptions<R, A, J, X, Carrier>,
+): DeterministicProductUniversalPropertyResult<R, A, J, X, Carrier> {
+  const { infObj } = witness;
+  const { family } = infObj;
+  const { domain, components, samples: providedSamples, alternate, partitions } = options;
+
+  if (!candidate.base) {
+    throw new Error("Deterministic mediator candidate must supply a base function.");
+  }
+
+  const samples = providedSamples ?? domain.object.elems;
+  const componentReports: DeterministicComponentDeterminismReport<A, J, X>[] = [];
+  const componentBases = new Map<J, (input: A) => X>();
+  const duplicateFailures: DeterministicKolmogorovFactorizationFailure<J>[] = [];
+
+  for (const component of components) {
+    if (component.arrow.X !== domain.object) {
+      throw new Error("Component arrow domain does not match the provided domain witness object.");
+    }
+    if (component.arrow.Y !== component.witness.object) {
+      throw new Error("Component arrow codomain must match the supplied comonoid witness object.");
+    }
+
+    const pairObject = tensorObj(component.witness.object, terminalComonoidWitness.object);
+    const tensorWitness = buildMarkovPositivityWitness(component.witness, terminalComonoidWitness, {
+      tensor: buildMarkovComonoidWitness(pairObject, {
+        label: component.label ? `${component.label} ⊗ I` : undefined,
+      }),
+      label: component.label ? `${component.label} × terminal` : undefined,
+    });
+    const pairedArrow = new FinMarkov(
+      domain.object,
+      pairObject,
+      pair(component.arrow.k, domain.discard.k),
+    );
+    const determinismReport = checkDeterministicTensorViaMarginals(domain, tensorWitness, pairedArrow, {
+      label: component.label ?? `component ${String(component.index)}`,
+    });
+    const deterministicMarginal = determinismReport.left.deterministic;
+    componentReports.push({
+      index: component.index,
+      label: component.label,
+      report: determinismReport,
+      ok: deterministicMarginal,
+    });
+
+    if (componentBases.has(component.index)) {
+      duplicateFailures.push({
+        index: component.index,
+        reason: `Duplicate deterministic component provided for index ${String(component.index)}.`,
+      });
+      continue;
+    }
+
+    const base =
+      component.base ??
+      ensureDeterministicBase(component.arrow, component.label ?? `component ${String(component.index)}`);
+    componentBases.set(component.index, base);
+  }
+
+  const determinismFailures = componentReports
+    .filter((entry) => !entry.ok)
+    .map<DeterministicKolmogorovFactorizationFailure<J>>((entry) => ({
+      index: entry.index,
+      reason: entry.report.left.details,
+    }));
+
+  const missingIndices = subset.filter((index) => !componentBases.has(index));
+  const missingFailures = missingIndices.map<DeterministicKolmogorovFactorizationFailure<J>>((index) => ({
+    index,
+    reason: `No deterministic component supplied for index ${String(index)}.`,
+  }));
+
+  const preflightFailures = [...determinismFailures, ...duplicateFailures, ...missingFailures];
+
+  let factorization: DeterministicKolmogorovFactorization<R, A, J, X, Carrier>;
+  if (preflightFailures.length === 0) {
+    const factorInputs = subset.map((index) => ({ index, base: componentBases.get(index)! }));
+    factorization = witness.factor(factorInputs);
+  } else {
+    factorization = {
+      ok: false,
+      subset,
+      details: `${preflightFailures.length} component issue${preflightFailures.length === 1 ? "" : "s"} prevented deterministic factorization.`,
+      failures: preflightFailures,
+    };
+  }
+
+  const candidateBase = candidate.base;
+  const mismatches: DeterministicMediatorMismatch<A, J, X, Carrier>[] = [];
+
+  if (factorization.ok && factorization.base) {
+    for (const input of samples) {
+      const expectedCarrier = factorization.base(input);
+      const actualCarrier = candidateBase(input);
+      const expectedSection = family.project(expectedCarrier, subset);
+      const actualSection = family.project(actualCarrier, subset);
+      if (!sectionsEqual(expectedSection, actualSection)) {
+        mismatches.push({
+          input,
+          subset: [...subset] as FiniteSubset<J>,
+          expected: { carrier: expectedCarrier, section: expectedSection },
+          actual: { carrier: actualCarrier, section: actualSection },
+        });
+      }
+    }
+  }
+
+  const mediatorAgreement = factorization.ok && factorization.base !== undefined && mismatches.length === 0;
+
+  let uniqueness:
+    | DeterministicProductUniversalPropertyResult<R, A, J, X, Carrier>["uniqueness"]
+    | undefined;
+
+  if (alternate) {
+    if (!alternate.base) {
+      throw new Error("Alternate mediator candidate must supply a base function.");
+    }
+    const uniquenessMismatches: DeterministicMediatorMismatch<A, J, X, Carrier>[] = [];
+    for (const input of samples) {
+      const primaryCarrier = candidateBase(input);
+      const alternateCarrier = alternate.base(input);
+      const primarySection = family.project(primaryCarrier, subset);
+      const alternateSection = family.project(alternateCarrier, subset);
+      if (!sectionsEqual(primarySection, alternateSection)) {
+        uniquenessMismatches.push({
+          input,
+          subset: [...subset] as FiniteSubset<J>,
+          expected: { carrier: primaryCarrier, section: primarySection },
+          actual: { carrier: alternateCarrier, section: alternateSection },
+        });
+      }
+    }
+    uniqueness = {
+      ok: uniquenessMismatches.length === 0,
+      mismatches: uniquenessMismatches,
+      label: alternate.label,
+    };
+  }
+
+  const partitionReports: DeterministicProductPartitionReport<R, A, J, X, Carrier>[] = [];
+  if (partitions) {
+    for (const block of partitions) {
+      const blockMissing = block.filter((index) => !componentBases.has(index));
+      const blockFailures = blockMissing.map<DeterministicKolmogorovFactorizationFailure<J>>((index) => ({
+        index,
+        reason: `No deterministic component supplied for index ${String(index)} in partition subset.`,
+      }));
+
+      let blockWitness: DeterministicKolmogorovProductWitness<R, J, X, Carrier> | undefined;
+      let blockFactorization: DeterministicKolmogorovFactorization<R, A, J, X, Carrier>;
+
+      if (blockFailures.length === 0) {
+        blockWitness = witness.restrict(block);
+        const blockInputs = block.map((index) => ({ index, base: componentBases.get(index)! }));
+        blockFactorization = blockWitness.factor(blockInputs);
+      } else {
+        blockFactorization = {
+          ok: false,
+          subset: block,
+          details: `${blockFailures.length} component issue${blockFailures.length === 1 ? "" : "s"} prevented factorization on the partition subset.`,
+          failures: blockFailures,
+        };
+      }
+
+      const blockMismatches: DeterministicMediatorMismatch<A, J, X, Carrier>[] = [];
+      if (blockFactorization.ok && blockFactorization.base && blockWitness) {
+        for (const input of samples) {
+          const expectedCarrier = blockFactorization.base(input);
+          const actualCarrier = candidateBase(input);
+          const expectedSection = blockWitness.infObj.family.project(expectedCarrier, block);
+          const actualSection = blockWitness.infObj.family.project(actualCarrier, block);
+          if (!sectionsEqual(expectedSection, actualSection)) {
+            blockMismatches.push({
+              input,
+              subset: [...block] as FiniteSubset<J>,
+              expected: { carrier: expectedCarrier, section: expectedSection },
+              actual: { carrier: actualCarrier, section: actualSection },
+            });
+          }
+        }
+      }
+
+      const blockOk = blockFactorization.ok && blockFactorization.base !== undefined && blockMismatches.length === 0;
+      const blockDetails = blockFactorization.ok
+        ? blockOk
+          ? `Candidate agrees with deterministic mediator on subset {${describeSubset(block)}}.`
+          : `${blockMismatches.length} mediator mismatch${blockMismatches.length === 1 ? "" : "es"} detected on subset {${describeSubset(block)}}.`
+        : blockFactorization.details;
+
+      partitionReports.push({
+        subset: block,
+        factorization: blockFactorization,
+        mismatches: blockMismatches,
+        ok: blockOk,
+        details: blockDetails,
+      });
+    }
+  }
+
+  const componentsOk = componentReports.every((entry) => entry.ok);
+  const factorOk = factorization.ok && factorization.base !== undefined;
+  const uniquenessOk = uniqueness ? uniqueness.ok : true;
+  const partitionsOk = partitionReports.every((report) => report.ok);
+
+  const countable = isCountableIndex(family);
+  const measurable = hasMeasurabilityWitness(family);
+  const standardBorel = isStandardBorelFamily(family);
+  const positivity = infObj.positivity ?? family.positivity;
+  const positive = positivity?.kind === "positive";
+
+  const ok = componentsOk && factorOk && mediatorAgreement && uniquenessOk && partitionsOk;
+
+  const failureReasons: string[] = [];
+  if (!componentsOk) {
+    failureReasons.push(`${componentReports.filter((entry) => !entry.ok).length} component determinism check${componentReports.filter((entry) => !entry.ok).length === 1 ? "" : "s"} failed`);
+  }
+  if (!factorOk) {
+    failureReasons.push("factorization did not produce a deterministic mediator");
+  }
+  if (factorOk && !mediatorAgreement) {
+    failureReasons.push(`${mismatches.length} mediator mismatch${mismatches.length === 1 ? "" : "es"}`);
+  }
+  if (!uniquenessOk) {
+    const count = uniqueness?.mismatches.length ?? 0;
+    failureReasons.push(`${count} uniqueness mismatch${count === 1 ? "" : "es"}`);
+  }
+  if (!partitionsOk) {
+    failureReasons.push(`${partitionReports.filter((report) => !report.ok).length} partition check${partitionReports.filter((report) => !report.ok).length === 1 ? "" : "s"} failed`);
+  }
+
+  const details = ok
+    ? `Deterministic mediator ${candidate.label ?? "candidate"} factors uniquely through indices {${describeSubset(subset)}}.`
+    : failureReasons.join("; ") || "Deterministic product universal property failed.";
+
+  return {
+    ok,
+    subset,
+    components: componentReports,
+    factorization,
+    mediatorAgreement,
+    mismatches,
+    uniqueness,
+    partitions: partitionReports,
+    countable,
+    witness: family.countability,
+    measurable,
+    measurability: family.measurability,
+    standardBorel,
+    positive,
+    positivity,
+    details,
+    candidateLabel: candidate.label,
+  };
+}
+
+export interface MarginalDeterminismFailure<R, J, X, Carrier> {
+  readonly subset: FiniteSubset<J>;
+  readonly sample: Carrier;
+  readonly distribution: Dist<R, CylinderSection<J, X>>;
+}
+
+export interface KolmogorovProductResult<R, J, X, Carrier> {
+  readonly ok: boolean;
+  readonly deterministic: boolean;
+  readonly determinismFailures: ReadonlyArray<MarginalDeterminismFailure<R, J, X, Carrier>>;
+  readonly copyDiscard: CopyDiscardCompatibilityResult<R, J, X, Carrier>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function checkKolmogorovProduct<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  subsets: ReadonlyArray<FiniteSubset<J>>,
+  samples: ReadonlyArray<Carrier>
+): KolmogorovProductResult<R, J, X, Carrier> {
+  const copyDiscard = checkCopyDiscardCompatibility(obj, subsets, samples);
+  const failures: Array<MarginalDeterminismFailure<R, J, X, Carrier>> = [];
+  const { semiring: R } = obj.family;
+  const isZero = defaultIsZero(R);
+
+  const positivity = obj.positivity ?? obj.family.positivity;
+  const collectSingletons = (): ReadonlyArray<FiniteSubset<J>> => {
+    const seen = new Set<J>();
+    const ordered: J[] = [];
+    const add = (index: J) => {
+      if (!seen.has(index)) {
+        seen.add(index);
+        ordered.push(index);
+      }
+    };
+
+    if (positivity?.indices) {
+      for (const index of positivity.indices) add(index);
+    }
+    for (const subset of subsets) {
+      for (const index of subset) add(index);
+    }
+    if (ordered.length === 0) {
+      let count = 0;
+      const POSITIVITY_INDEX_LIMIT = 256;
+      for (const index of obj.family.index) {
+        add(index);
+        count += 1;
+        if (count >= POSITIVITY_INDEX_LIMIT) break;
+      }
+    }
+    return ordered.map((index) => [index]);
+  };
+
+  const deterministicSubsets =
+    positivity?.kind === "positive" ? collectSingletons() : subsets;
+
+  for (const sample of samples) {
+    for (const subset of deterministicSubsets) {
+      const projection = obj.projectKernel(subset)(sample);
+      let support = 0;
+      projection.w.forEach((weight) => {
+        if (!isZero(weight)) {
+          support += 1;
+        }
+      });
+      if (support !== 1) {
+        failures.push({
+          subset,
+          sample,
+          distribution: aggregateCylinderDist(R, projection),
+        });
+      }
+    }
+  }
+
+  const deterministic = failures.length === 0;
+
+  return {
+    ok: deterministic && copyDiscard.ok,
+    deterministic,
+    determinismFailures: failures,
+    copyDiscard,
+    countable: copyDiscard.countable,
+    witness: copyDiscard.witness,
+    measurable: copyDiscard.measurable,
+    measurability: copyDiscard.measurability,
+    standardBorel: copyDiscard.standardBorel,
+  };
+}
+
+export interface KolmogorovExtensionSuccess<R, J, X, Carrier> {
+  readonly ok: true;
+  readonly baseSubset: FiniteSubset<J>;
+  readonly measure: Dist<R, Carrier>;
+  readonly reductions: ReadonlyArray<FiniteReductionResult<R, J, X>>;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export interface KolmogorovExtensionFailure<J> {
+  readonly ok: false;
+  readonly reason: string;
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export type KolmogorovExtensionResult<R, J, X, Carrier> =
+  | KolmogorovExtensionSuccess<R, J, X, Carrier>
+  | KolmogorovExtensionFailure<J>;
+
+export function checkKolmogorovExtensionUniversalProperty<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  subsets: ReadonlyArray<FiniteSubset<J>>
+): KolmogorovExtensionResult<R, J, X, Carrier> {
+  const baseSubset = subsets.length === 0 ? [] : subsets.reduce<FiniteSubset<J>>((acc, subset) => {
+    const seen = new Set(acc);
+    const next: J[] = [...acc];
+    for (const item of subset) {
+      if (!seen.has(item)) {
+        seen.add(item);
+        next.push(item);
+      }
+    }
+    return next;
+  }, [] as J[]);
+
+  const extension = kolmogorovExtensionMeasure(obj.family, subsets);
+  if (!extension.ok) {
+    return {
+      ok: false,
+      reason: extension.reason,
+      countable: isCountableIndex(obj.family),
+      witness: obj.family.countability,
+      measurable: hasMeasurabilityWitness(obj.family),
+      measurability: obj.family.measurability,
+      standardBorel: isStandardBorelFamily(obj.family),
+    };
+  }
+
+  const { measure } = extension;
+  const reductions = subsets.map((subset) => checkFiniteProductReduction(obj, measure, subset));
+  const ok = reductions.every((result) => result.ok);
+
+  return {
+    ok,
+    baseSubset: extension.baseSubset,
+    measure,
+    reductions,
+    countable: isCountableIndex(obj.family),
+    witness: obj.family.countability,
+    measurable: hasMeasurabilityWitness(obj.family),
+    measurability: obj.family.measurability,
+    standardBorel: isStandardBorelFamily(obj.family),
+  };
+}
+
+export function hewittSavageZeroOneWitness<R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  measure: Dist<R, Carrier>,
+  tailEvent: KernelR<R, Carrier, boolean>,
+  permutations: ReadonlyArray<(carrier: Carrier) => Carrier>
+): ExchangeabilityResult<R, J, Carrier> {
+  const R = obj.family.semiring;
+  if (measure.R !== R) {
+    throw new Error("Measure semiring does not match projective family semiring");
+  }
+
+  const isZero = defaultIsZero(R);
+  let exchangeable = true;
+  for (const perm of permutations) {
+    const pushed = map(measure, perm);
+    if (!equalDist(R, measure, pushed)) {
+      exchangeable = false;
+      break;
+    }
+  }
+
+  const counterexamples: Array<{ original: Carrier; permuted: Carrier }> = [];
+  let invariant = true;
+  measure.w.forEach((_weight, carrier) => {
+    const base = deterministicBooleanValue(R, tailEvent(carrier));
+    for (const perm of permutations) {
+      const permuted = perm(carrier);
+      const value = deterministicBooleanValue(R, tailEvent(permuted));
+      if (value !== base) {
+        counterexamples.push({ original: carrier, permuted });
+        invariant = false;
+      }
+    }
+  });
+
+  const support = bind(measure, tailEvent);
+  const probTrue = support.w.get(true) ?? R.zero;
+  const probFalse = support.w.get(false) ?? R.zero;
+  const zeroOrOne = R.eq(probTrue, R.one) || isZero(probTrue) || R.eq(probFalse, R.one) || isZero(probFalse);
+
+  return {
+    ok: exchangeable && invariant && zeroOrOne,
+    exchangeable,
+    invariant,
+    probability: probTrue,
+    support,
+    counterexamples,
+    countable: isCountableIndex(obj.family),
+    witness: obj.family.countability,
+    measurable: hasMeasurabilityWitness(obj.family),
+    measurability: obj.family.measurability,
+    standardBorel: isStandardBorelFamily(obj.family),
+  };
+}
+
+const DEFAULT_FINSTOCH_SAMPLE_LIMIT = 512;
+const DEFAULT_FINSTOCH_THRESHOLD = 32;
+const MAX_FACTOR_SAMPLES = 16;
+
+export type FinStochInfiniteTensorStatus = "ok" | "obstructed" | "likelyObstructed" | "inconclusive";
+
+export interface FinStochFactorInfo<J> {
+  readonly index: J;
+  readonly label: string;
+  readonly size: number;
+}
+
+export interface FinStochInfiniteTensorOptions<J> {
+  readonly sampleLimit?: number;
+  readonly threshold?: number;
+  readonly describeIndex?: (index: J) => string;
+  readonly countability?: CountabilityWitness<J>;
+}
+
+export interface FinStochInfiniteTensorResult<J> {
+  readonly status: FinStochInfiniteTensorStatus;
+  readonly details: string;
+  readonly inspected: number;
+  readonly sampleLimit: number;
+  readonly exhausted: boolean;
+  readonly truncated: boolean;
+  readonly emptyFactors: ReadonlyArray<FinStochFactorInfo<J>>;
+  readonly multiValuedFactors: ReadonlyArray<FinStochFactorInfo<J>>;
+  readonly multiValuedCount: number;
+  readonly countability?: CountabilityWitness<J>;
+}
+
+export function analyzeFinStochInfiniteTensor<J>(
+  index: Iterable<J>,
+  carrier: (index: J) => Fin<unknown>,
+  options: FinStochInfiniteTensorOptions<J> = {}
+): FinStochInfiniteTensorResult<J> {
+  const sampleLimit = options.sampleLimit ?? DEFAULT_FINSTOCH_SAMPLE_LIMIT;
+  const threshold = Math.max(1, Math.min(options.threshold ?? DEFAULT_FINSTOCH_THRESHOLD, sampleLimit));
+  const describe = options.describeIndex ?? ((idx: J) => `${String(idx)}`);
+  const enumeration = options.countability?.enumerate() ?? index;
+  const iterator = enumeration[Symbol.iterator]();
+
+  let inspected = 0;
+  let exhausted = false;
+  const emptyFactors: Array<FinStochFactorInfo<J>> = [];
+  const multiValuedSamples: Array<FinStochFactorInfo<J>> = [];
+  let multiValuedCount = 0;
+
+  while (inspected < sampleLimit) {
+    const next = iterator.next();
+    if (next.done) {
+      exhausted = true;
+      break;
+    }
+
+    inspected += 1;
+    const idx = next.value;
+    const fin = carrier(idx);
+    const size = fin.elems.length;
+    const info: FinStochFactorInfo<J> = { index: idx, label: describe(idx), size };
+
+    if (size === 0) {
+      if (emptyFactors.length < MAX_FACTOR_SAMPLES) emptyFactors.push(info);
+    } else if (size >= 2) {
+      multiValuedCount += 1;
+      if (multiValuedSamples.length < MAX_FACTOR_SAMPLES) multiValuedSamples.push(info);
+    }
+  }
+
+  let truncated = !exhausted && inspected >= sampleLimit;
+  if (truncated) {
+    const peek = iterator.next();
+    if (peek.done) {
+      exhausted = true;
+      truncated = false;
+    } else {
+      truncated = true;
+    }
+  }
+
+  let status: FinStochInfiniteTensorStatus;
+  let details: string;
+
+  if (emptyFactors.length > 0) {
+    status = "obstructed";
+    details = `Encountered ${emptyFactors.length} empty factor${emptyFactors.length === 1 ? "" : "s"}; a FinStoch infinite tensor cannot exist with an empty component.`;
+  } else if (truncated && multiValuedCount >= threshold) {
+    status = "likelyObstructed";
+    details = `Observed ${multiValuedCount} multi-valued factors without exhausting the index; Example 3.7 predicts no FinStoch tensor when infinitely many factors have size ≥ 2.`;
+  } else if (truncated) {
+    status = "inconclusive";
+    details = `Inspected ${inspected} factors (limit ${sampleLimit}) without exhausting the index; insufficient evidence to certify the Example 3.7 obstruction.`;
+  } else {
+    status = "ok";
+    details = `Enumeration exhausted after ${inspected} factors; only ${multiValuedCount} factor${multiValuedCount === 1 ? "" : "s"} had size ≥ 2, so the Example 3.7 obstruction does not apply.`;
+  }
+
+  return {
+    status,
+    details,
+    inspected,
+    sampleLimit,
+    exhausted,
+    truncated,
+    emptyFactors,
+    multiValuedFactors: multiValuedSamples,
+    multiValuedCount,
+    countability: options.countability,
+  };
+}

--- a/markov-infinite.ts
+++ b/markov-infinite.ts
@@ -1,0 +1,1342 @@
+import type { CSRig } from "./semiring-utils";
+import type { Dist } from "./dist";
+import { bind, dirac, map } from "./dist";
+import type { FinMarkov } from "./markov-category";
+import type { MarkovComonoidWitness } from "./markov-comonoid-structure";
+import type { MarkovConditionalWitness } from "./markov-conditional-independence";
+import type { DeterminismLemmaWitness } from "./markov-deterministic-structure";
+
+export type KernelR<R, A, B> = (a: A) => Dist<R, B>;
+export type FiniteSubset<J> = ReadonlyArray<J>;
+export type CylinderSection<J, X> = ReadonlyMap<J, X>;
+export type ProjectiveLimitSection<J, X> = (index: J) => X;
+export type Terminal = {};
+
+const terminalValue: Terminal = {};
+
+const defaultIsZero = <R>(R: CSRig<R>) => R.isZero ?? ((a: R) => R.eq(a, R.zero));
+
+export interface DoubleIndex<K, J> {
+  readonly outer: K;
+  readonly inner: J;
+}
+
+export const createDoubleIndexFactory = <K, J>() => {
+  const cache = new Map<K, Map<J, DoubleIndex<K, J>>>();
+  return (outer: K, inner: J): DoubleIndex<K, J> => {
+    let innerCache = cache.get(outer);
+    if (!innerCache) {
+      innerCache = new Map<J, DoubleIndex<K, J>>();
+      cache.set(outer, innerCache);
+    }
+    let entry = innerCache.get(inner);
+    if (!entry) {
+      entry = { outer, inner } as const;
+      innerCache.set(inner, entry);
+    }
+    return entry;
+  };
+};
+
+export type TensorSide = "left" | "right";
+export type LeftIndex<J> = DoubleIndex<"left", J>;
+export type RightIndex<J> = DoubleIndex<"right", J>;
+export type TensorIndex<JL, JR> = LeftIndex<JL> | RightIndex<JR>;
+export type TensorCarrier<CL, CR> = readonly [CL, CR];
+
+export interface KolmogorovWitness<J> {
+  readonly check: (finite: FiniteSubset<J>, larger: FiniteSubset<J>) => boolean;
+  readonly explanation?: string;
+}
+
+export type CountabilityKind = "finite" | "countablyInfinite";
+
+export interface CountabilityWitness<J> {
+  readonly kind: CountabilityKind;
+  readonly enumerate: () => Iterable<J>;
+  readonly sample: ReadonlyArray<J>;
+  readonly reason?: string;
+  readonly size?: number;
+}
+
+export type MeasurabilityKind = "unknown" | "measurable" | "standardBorel";
+
+export interface CoordinateMeasurability<J> {
+  readonly index: J;
+  readonly sigmaAlgebra?: string;
+  readonly witness?: unknown;
+  readonly standardBorel?: boolean;
+}
+
+export interface MeasurabilityWitness<J> {
+  readonly kind: MeasurabilityKind;
+  readonly coordinates?: ReadonlyArray<CoordinateMeasurability<J>>;
+  readonly reason?: string;
+}
+
+export interface PositivityWitness<J> {
+  readonly kind: "positive";
+  readonly indices?: ReadonlyArray<J>;
+  readonly reason?: string;
+}
+
+export interface ProjectiveFamily<R, J, X, Carrier = ProjectiveLimitSection<J, X>> {
+  readonly semiring: CSRig<R>;
+  readonly index: Iterable<J>;
+  readonly coordinate: (index: J) => Dist<R, X>;
+  readonly marginal: (finite: FiniteSubset<J>) => Dist<R, CylinderSection<J, X>>;
+  readonly project: (carrier: Carrier, finite: FiniteSubset<J>) => CylinderSection<J, X>;
+  readonly extend?: (finite: FiniteSubset<J>, section: CylinderSection<J, X>) => Carrier;
+  readonly update?: (carrier: Carrier, section: CylinderSection<J, X>) => Carrier;
+  readonly kolmogorov?: KolmogorovWitness<J>;
+  readonly countability?: CountabilityWitness<J>;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly positivity?: PositivityWitness<J>;
+}
+
+export const enumerateDoubleIndex = <K, J>(
+  outer: Iterable<K>,
+  inner: (outer: K) => Iterable<J>,
+  toIndex: (outer: K, inner: J) => DoubleIndex<K, J>
+): Iterable<DoubleIndex<K, J>> => ({
+  [Symbol.iterator]: function* () {
+    for (const outerIndex of outer) {
+      for (const innerIndex of inner(outerIndex)) {
+        yield toIndex(outerIndex, innerIndex);
+      }
+    }
+  },
+});
+
+export const flattenNestedSection = <K, J, X>(
+  nested: ProjectiveLimitSection<K, ProjectiveLimitSection<J, X>>
+): ProjectiveLimitSection<DoubleIndex<K, J>, X> =>
+  (index) => nested(index.outer)(index.inner);
+
+export const nestSection = <K, J, X>(
+  flattened: ProjectiveLimitSection<DoubleIndex<K, J>, X>
+): ProjectiveLimitSection<K, ProjectiveLimitSection<J, X>> =>
+  (outer) => (inner) => flattened({ outer, inner });
+
+export type NestedCylinderSection<K, J, X> = ReadonlyMap<K, CylinderSection<J, X>>;
+
+export const flattenNestedCylinder = <K, J, X>(
+  nested: NestedCylinderSection<K, J, X>,
+  toIndex: (outer: K, inner: J) => DoubleIndex<K, J>
+): CylinderSection<DoubleIndex<K, J>, X> => {
+  const result = new Map<DoubleIndex<K, J>, X>();
+  nested.forEach((innerSection, outerIndex) => {
+    innerSection.forEach((value, innerIndex) => {
+      result.set(toIndex(outerIndex, innerIndex), value);
+    });
+  });
+  return result;
+};
+
+export const nestCylinder = <K, J, X>(
+  flattened: CylinderSection<DoubleIndex<K, J>, X>
+): NestedCylinderSection<K, J, X> => {
+  const result = new Map<K, Map<J, X>>();
+  flattened.forEach((value, index) => {
+    let inner = result.get(index.outer);
+    if (!inner) {
+      inner = new Map<J, X>();
+      result.set(index.outer, inner);
+    }
+    inner.set(index.inner, value);
+  });
+  const normalized = new Map<K, CylinderSection<J, X>>();
+  result.forEach((section, outerIndex) => {
+    normalized.set(outerIndex, new Map(section));
+  });
+  return normalized;
+};
+
+export const isCountableIndex = <R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>
+): family is ProjectiveFamily<R, J, X, Carrier> & { countability: CountabilityWitness<J> } =>
+  family.countability !== undefined &&
+  (family.countability.kind === "finite" || family.countability.kind === "countablyInfinite");
+
+export const hasMeasurabilityWitness = <R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>
+): family is ProjectiveFamily<R, J, X, Carrier> & { measurability: MeasurabilityWitness<J> } =>
+  family.measurability !== undefined;
+
+export const isStandardBorelFamily = <R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>
+): boolean => family.measurability?.kind === "standardBorel";
+
+const restrictCountabilityWitness = <J>(
+  subset: ReadonlySet<J>,
+  witness: CountabilityWitness<J>
+): CountabilityWitness<J> => ({
+  kind: witness.kind,
+  enumerate: () => ({
+    [Symbol.iterator]: function* () {
+      for (const value of witness.enumerate()) {
+        if (subset.has(value)) yield value;
+      }
+    },
+  }),
+  sample: witness.sample.filter((value) => subset.has(value)),
+  reason: witness.reason,
+});
+
+const restrictMeasurabilityWitness = <J>(
+  subset: ReadonlySet<J>,
+  witness: MeasurabilityWitness<J>
+): MeasurabilityWitness<J> => {
+  if (!witness.coordinates) return witness;
+  return {
+    kind: witness.kind,
+    coordinates: witness.coordinates.filter((coordinate) => subset.has(coordinate.index)),
+    reason: witness.reason,
+  };
+};
+
+const restrictPositivityWitness = <J>(
+  subset: ReadonlySet<J>,
+  witness: PositivityWitness<J>
+): PositivityWitness<J> => {
+  if (!witness.indices) return witness;
+  return {
+    kind: "positive",
+    reason: witness.reason,
+    indices: witness.indices.filter((index) => subset.has(index)),
+  };
+};
+
+export const restrictProjectiveFamily = <R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>,
+  subset: Iterable<J>
+): ProjectiveFamily<R, J, X, Carrier> => {
+  const allowed = new Set(subset as Iterable<J>);
+  const restrictedIndex: Iterable<J> = {
+    [Symbol.iterator]: function* () {
+      for (const index of family.index) {
+        if (allowed.has(index)) yield index;
+      }
+    },
+  };
+
+  const ensureSubset = (finite: FiniteSubset<J>) => {
+    for (const index of finite) {
+      if (!allowed.has(index)) {
+        throw new Error(`Index ${String(index)} is not contained in the restricted family.`);
+      }
+    }
+  };
+
+  const countability =
+    family.countability !== undefined ? restrictCountabilityWitness(allowed, family.countability) : undefined;
+  const measurability =
+    family.measurability !== undefined ? restrictMeasurabilityWitness(allowed, family.measurability) : undefined;
+  const positivity =
+    family.positivity !== undefined ? restrictPositivityWitness(allowed, family.positivity) : undefined;
+
+  return {
+    semiring: family.semiring,
+    index: restrictedIndex,
+    coordinate: (index: J) => {
+      if (!allowed.has(index)) {
+        throw new Error(`Coordinate ${String(index)} is outside the restricted subset.`);
+      }
+      return family.coordinate(index);
+    },
+    marginal: (finite) => {
+      ensureSubset(finite);
+      return family.marginal(finite);
+    },
+    project: (carrier, finite) => {
+      ensureSubset(finite);
+      return family.project(carrier, finite);
+    },
+    extend:
+      family.extend === undefined
+        ? undefined
+        : (finite, section) => {
+            ensureSubset(finite);
+            return family.extend?.(finite, section);
+          },
+    update:
+      family.update === undefined
+        ? undefined
+        : (carrier, section) => {
+            const filtered = new Map<J, X>();
+            section.forEach((value, index) => {
+              if (allowed.has(index)) filtered.set(index, value);
+            });
+            return family.update?.(carrier, filtered as CylinderSection<J, X>);
+          },
+    kolmogorov: family.kolmogorov,
+    countability,
+    measurability,
+    positivity,
+  };
+};
+
+export const restrictInfObj = <R, J, X, Carrier>(
+  obj: InfObj<R, J, X, Carrier>,
+  subset: Iterable<J>
+): InfObj<R, J, X, Carrier> => createInfObj(restrictProjectiveFamily(obj.family, subset));
+
+export interface InfObj<R, J, X, Carrier = ProjectiveLimitSection<J, X>> {
+  readonly family: ProjectiveFamily<R, J, X, Carrier>;
+  readonly copy: KernelR<R, Carrier, readonly [Carrier, Carrier]>;
+  readonly discard: KernelR<R, Carrier, Terminal>;
+  readonly projectKernel: (finite: FiniteSubset<J>) => KernelR<R, Carrier, CylinderSection<J, X>>;
+  readonly projectArray: (finite: FiniteSubset<J>) => KernelR<R, Carrier, ReadonlyArray<X>>;
+  readonly liftKernel: <Y>(finite: FiniteSubset<J>, kernel: KernelR<R, CylinderSection<J, X>, Y>) => KernelR<R, Carrier, Y>;
+  readonly deterministicProjection: (index: J) => (carrier: Carrier) => X;
+  readonly positivity?: PositivityWitness<J>;
+  readonly deterministicWitness?: () => DeterministicKolmogorovProductWitness<R, J, X, Carrier>;
+}
+
+const isSubset = <J>(finite: FiniteSubset<J>, larger: FiniteSubset<J>): boolean => {
+  const set = new Set(larger);
+  for (const j of finite) if (!set.has(j)) return false;
+  return true;
+};
+
+const isMapValue = (value: unknown): value is Map<unknown, unknown> => value instanceof Map;
+
+const mapsEqual = (a: Map<unknown, unknown>, b: Map<unknown, unknown>): boolean => {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    if (!b.has(key)) return false;
+    if (b.get(key) !== value) return false;
+  }
+  return true;
+};
+
+const keysEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+  if (isMapValue(a) && isMapValue(b)) return mapsEqual(a, b);
+  return false;
+};
+
+const getWeight = <R, X>(dist: Dist<R, X>, key: X): R | undefined => {
+  const direct = dist.w.get(key);
+  if (direct !== undefined) return direct;
+  for (const [candidate, weight] of dist.w) {
+    if (keysEqual(candidate, key)) return weight;
+  }
+  return undefined;
+};
+
+const collectKeys = <X>(a: Dist<any, X>, b: Dist<any, X>): X[] => {
+  const keys: X[] = [];
+  a.w.forEach((_v, k) => {
+    keys.push(k);
+  });
+  b.w.forEach((_v, k) => {
+    if (!keys.some(existing => keysEqual(existing, k))) keys.push(k);
+  });
+  return keys;
+};
+
+export const equalDist = <R, X>(R: CSRig<R>, a: Dist<R, X>, b: Dist<R, X>): boolean => {
+  const keys = collectKeys(a, b);
+  for (const key of keys) {
+    const va = getWeight(a, key) ?? R.zero;
+    const vb = getWeight(b, key) ?? R.zero;
+    if (!R.eq(va, vb)) return false;
+  }
+  return true;
+};
+
+const extendCylinder = <J, X>(section: CylinderSection<J, X>, index: J, value: X): CylinderSection<J, X> => {
+  const next = new Map<J, X>(section);
+  next.set(index, value);
+  return next;
+};
+
+const restrictCylinder = <J, X>(section: CylinderSection<J, X>, subset: FiniteSubset<J>): CylinderSection<J, X> => {
+  const next = new Map<J, X>();
+  for (const j of subset) {
+    if (!section.has(j)) continue;
+    const value = section.get(j);
+    if (value !== undefined || section.has(j)) {
+      next.set(j, value as X);
+    }
+  }
+  return next;
+};
+
+export function cylinderToArray<J, X>(subset: FiniteSubset<J>, section: CylinderSection<J, X>): ReadonlyArray<X> {
+  return subset.map((index) => {
+    if (!section.has(index)) {
+      throw new Error(`Cylinder section is missing value for index ${String(index)}`);
+    }
+    return section.get(index) as X;
+  });
+}
+
+export function pushforwardCylinderArray<R, J, X>(
+  subset: FiniteSubset<J>,
+  dist: Dist<R, CylinderSection<J, X>>
+): Dist<R, ReadonlyArray<X>> {
+  return map(dist, (section) => cylinderToArray(subset, section));
+}
+
+const pushforwardCylinder = <R, J, X>(
+  R: CSRig<R>,
+  dist: Dist<R, CylinderSection<J, X>>,
+  subset: FiniteSubset<J>
+): Dist<R, CylinderSection<J, X>> => {
+  type Entry = { section: Map<J, X>; weight: R };
+  const entries: Entry[] = [];
+  dist.w.forEach((weight, section) => {
+    const restricted = restrictCylinder(section, subset);
+    const existing = entries.find((candidate) => mapsEqual(candidate.section, restricted));
+    if (existing) {
+      existing.weight = R.add(existing.weight, weight);
+    } else {
+      entries.push({ section: restricted, weight });
+    }
+  });
+  const out: Dist<R, CylinderSection<J, X>> = { R: dist.R, w: new Map() };
+  for (const entry of entries) out.w.set(entry.section as CylinderSection<J, X>, entry.weight);
+  return out;
+};
+
+const patchSection = <J, X>(section: ProjectiveLimitSection<J, X>, patch: CylinderSection<J, X>): ProjectiveLimitSection<J, X> => {
+  const cache = new Map<J, X>(patch);
+  return (index: J) => (cache.has(index) ? (cache.get(index) as X) : section(index));
+};
+
+const expectDeterministicValue = <R, X>(dist: Dist<R, X>, reason: string): X => {
+  const entries = Array.from(dist.w.entries());
+  if (entries.length !== 1) {
+    throw new Error(`${reason}: distribution is not deterministic`);
+  }
+  const [[value, weight]] = entries as Array<[X, R]>;
+  if (!dist.R.eq(weight, dist.R.one)) {
+    throw new Error(`${reason}: deterministic distribution must have unit weight`);
+  }
+  return value;
+};
+
+export function createInfObj<R, J, X, Carrier = ProjectiveLimitSection<J, X>>(
+  family: ProjectiveFamily<R, J, X, Carrier>
+): InfObj<R, J, X, Carrier> {
+  const { semiring: Rsemiring } = family;
+  const delta = dirac(Rsemiring);
+
+  const projectKernel = (finite: FiniteSubset<J>): KernelR<R, Carrier, CylinderSection<J, X>> =>
+    (carrier) => delta(family.project(carrier, finite));
+
+  const liftKernel = <Y>(
+    finite: FiniteSubset<J>,
+    kernel: KernelR<R, CylinderSection<J, X>, Y>
+  ): KernelR<R, Carrier, Y> => (carrier) =>
+    bind(projectKernel(finite)(carrier), kernel);
+
+  const projectArray = (finite: FiniteSubset<J>): KernelR<R, Carrier, ReadonlyArray<X>> =>
+    (carrier) => pushforwardCylinderArray(finite, projectKernel(finite)(carrier));
+
+  const deterministicProjection = (index: J) => {
+    const subset: FiniteSubset<J> = [index];
+    const kernel = projectKernel(subset);
+    return (carrier: Carrier): X => {
+      const section = expectDeterministicValue(
+        kernel(carrier),
+        `Projection onto index ${String(index)}`
+      ) as CylinderSection<J, X>;
+      if (!section.has(index)) {
+        throw new Error(`Projection section is missing value for index ${String(index)}`);
+      }
+      return section.get(index) as X;
+    };
+  };
+
+  let self: InfObj<R, J, X, Carrier>;
+  let cached: DeterministicKolmogorovProductWitness<R, J, X, Carrier> | undefined;
+
+  const deterministicWitness =
+    family.positivity !== undefined
+      ? () => {
+          if (!cached) {
+            cached = buildDeterministicKolmogorovProductWitness(self);
+          }
+          return cached;
+        }
+      : undefined;
+
+  self = {
+    family,
+    copy: (carrier) => delta([carrier, carrier] as const),
+    discard: () => delta(terminalValue),
+    projectKernel,
+    projectArray,
+    liftKernel,
+    deterministicProjection,
+    positivity: family.positivity,
+    deterministicWitness,
+  };
+  return self;
+}
+
+export const asDeterministicKernel = <R, A, B>(R: CSRig<R>, base: (input: A) => B): KernelR<R, A, B> => {
+  const delta = dirac(R);
+  return (input: A) => delta(base(input));
+};
+
+const COUNTABILITY_SAMPLE_LIMIT = 1024;
+
+const inferCountabilityWitness = <J>(index: Iterable<J>): CountabilityWitness<J> => {
+  const iterator = index[Symbol.iterator]();
+  const selfIterable = iterator === index;
+  const samples: J[] = [];
+  const seen = new Set<unknown>();
+  for (let i = 0; i < COUNTABILITY_SAMPLE_LIMIT; i += 1) {
+    const next = iterator.next();
+    if (next.done) {
+      const snapshot = samples.slice();
+      return {
+        kind: "finite",
+        enumerate: () => snapshot,
+        sample: snapshot,
+        size: snapshot.length,
+        reason: `Iterable terminated after ${snapshot.length} elements`,
+      };
+    }
+    if (seen.has(next.value)) {
+      throw new Error(`Index iterable repeats element ${String(next.value)}`);
+    }
+    seen.add(next.value as unknown);
+    samples.push(next.value);
+  }
+  if (selfIterable) {
+    throw new Error(
+      "Index iterable must return a fresh iterator from Symbol.iterator(); provide a replayable enumeration for countably infinite families"
+    );
+  }
+
+  const snapshot = samples.slice();
+  return {
+    kind: "countablyInfinite",
+    enumerate: () => index,
+    sample: snapshot,
+    reason: `Observed at least ${COUNTABILITY_SAMPLE_LIMIT} distinct indices; treating iterable as a countable enumeration`,
+  };
+};
+
+const ensureIterable = <T>(iterable: Iterable<T> | undefined): iterable is Iterable<T> =>
+  iterable !== undefined && typeof iterable[Symbol.iterator] === "function";
+
+const validateCountabilityWitness = <J>(witness: CountabilityWitness<J>): CountabilityWitness<J> => {
+  const enumeration = witness.enumerate();
+  if (!ensureIterable(enumeration)) {
+    throw new Error("Countability witness must supply an iterable enumeration");
+  }
+
+  const iterator = enumeration[Symbol.iterator]();
+  if (iterator === enumeration) {
+    throw new Error(
+      "Countability witness must return a replayable iterable from enumerate(); wrap generators in an array or similar container"
+    );
+  }
+
+  const seen = new Set<unknown>();
+  let steps = 0;
+  while (steps < COUNTABILITY_SAMPLE_LIMIT) {
+    const next = iterator.next();
+    if (next.done) break;
+    if (seen.has(next.value)) {
+      throw new Error(`Countability witness repeats element ${String(next.value)}`);
+    }
+    seen.add(next.value as unknown);
+    steps += 1;
+    if (witness.kind === "countablyInfinite" && steps >= COUNTABILITY_SAMPLE_LIMIT) {
+      break;
+    }
+  }
+
+  if (witness.kind === "finite") {
+    const replay = witness.enumerate();
+    if (!ensureIterable(replay)) {
+      throw new Error("Countability witness must replay enumeration as an iterable");
+    }
+    const replaySet = new Set<unknown>();
+    let total = 0;
+    for (const value of replay) {
+      if (replaySet.has(value)) {
+        throw new Error(`Countability witness repeats element ${String(value)} on replay`);
+      }
+      replaySet.add(value as unknown);
+      total += 1;
+    }
+    if (witness.size !== undefined && witness.size !== total) {
+      throw new Error(
+        `Countability witness size ${witness.size} disagrees with enumerate() length ${total}`
+      );
+    }
+  }
+
+  const sampleSet = new Set<unknown>();
+  for (const value of witness.sample) {
+    if (sampleSet.has(value)) {
+      throw new Error(`Countability witness sample repeats element ${String(value)}`);
+    }
+    sampleSet.add(value as unknown);
+  }
+
+  return witness;
+};
+
+export interface IndependentIndexedProductOptions<J> {
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly countability?: CountabilityWitness<J>;
+  readonly positivity?: PositivityWitness<J>;
+}
+
+export function independentIndexedProduct<R, J, X>(
+  R: CSRig<R>,
+  index: Iterable<J>,
+  coordinate: (idx: J) => Dist<R, X>,
+  options: IndependentIndexedProductOptions<J> = {}
+): ProjectiveFamily<R, J, X> {
+  const isZero = defaultIsZero(R);
+  const countability =
+    options.countability !== undefined
+      ? validateCountabilityWitness(options.countability)
+      : inferCountabilityWitness(index);
+  const { measurability, positivity } = options;
+
+  const marginal = (finite: FiniteSubset<J>): Dist<R, CylinderSection<J, X>> => {
+    type Entry = { section: Map<J, X>; weight: R };
+    let acc: Entry[] = [{ section: new Map<J, X>(), weight: R.one }];
+
+    for (const j of finite) {
+      const next: Entry[] = [];
+      const dj = coordinate(j);
+      for (const entry of acc) {
+        dj.w.forEach((prob, value) => {
+          const weight = R.mul(entry.weight, prob);
+          if (isZero(weight)) return;
+          const section = new Map(entry.section);
+          section.set(j, value);
+          const existing = next.find((candidate) => mapsEqual(candidate.section, section));
+          if (existing) {
+            existing.weight = R.add(existing.weight, weight);
+          } else {
+            next.push({ section, weight });
+          }
+        });
+      }
+      acc = next;
+    }
+
+    const dist: Dist<R, CylinderSection<J, X>> = { R, w: new Map() };
+    for (const entry of acc) {
+      dist.w.set(entry.section as CylinderSection<J, X>, entry.weight);
+    }
+    return dist;
+  };
+
+  const project = (section: ProjectiveLimitSection<J, X>, finite: FiniteSubset<J>) => {
+    const out = new Map<J, X>();
+    for (const j of finite) out.set(j, section(j));
+    return out;
+  };
+
+  const update = (section: ProjectiveLimitSection<J, X>, patch: CylinderSection<J, X>) => patchSection(section, patch);
+
+  const defaultCache = new Map<J, X>();
+  const defaultValue = (index: J): X => {
+    const cached = defaultCache.get(index);
+    if (cached !== undefined) return cached;
+    const dist = coordinate(index);
+    for (const value of dist.w.keys()) {
+      defaultCache.set(index, value);
+      return value;
+    }
+    throw new Error("Coordinate distribution must have at least one support value");
+  };
+
+  const extend = (finite: FiniteSubset<J>, section: CylinderSection<J, X>) => {
+    const lookup = new Map(section);
+    for (const index of finite) {
+      if (!lookup.has(index)) {
+        throw new Error(`Cylinder section missing value for index ${String(index)}`);
+      }
+    }
+    return (index: J) => (lookup.has(index) ? (lookup.get(index) as X) : defaultValue(index));
+  };
+
+  const witness: KolmogorovWitness<J> = {
+    check: (finite, larger) => {
+      if (!isSubset(finite, larger)) return false;
+      const small = marginal(finite);
+      const restricted = pushforwardCylinder(R, marginal(larger), finite);
+      return equalDist(R, small, restricted);
+    },
+    explanation: "Independent family Kolmogorov consistency",
+  };
+
+  return {
+    semiring: R,
+    index,
+    coordinate,
+    marginal,
+    project,
+    update,
+    extend,
+    kolmogorov: witness,
+    countability,
+    measurability,
+    positivity,
+  };
+}
+
+export interface IndependentDoubleIndexedProductOptions<K, J> {
+  readonly countability?: CountabilityWitness<DoubleIndex<K, J>>;
+  readonly measurability?: MeasurabilityWitness<DoubleIndex<K, J>>;
+  readonly positivity?: PositivityWitness<DoubleIndex<K, J>>;
+}
+
+export interface DoubleIndexedIndependentProductResult<R, K, J, X> {
+  readonly family: ProjectiveFamily<R, DoubleIndex<K, J>, X>;
+  readonly infObj: InfObj<R, DoubleIndex<K, J>, X>;
+  readonly toIndex: (outer: K, inner: J) => DoubleIndex<K, J>;
+  readonly innerFamilies: ReadonlyMap<K, ProjectiveFamily<R, J, X>>;
+}
+
+export function independentDoubleIndexedProduct<R, K, J, X>(
+  R: CSRig<R>,
+  outerIndex: Iterable<K>,
+  innerIndex: (outer: K) => Iterable<J>,
+  coordinate: (outer: K, inner: J) => Dist<R, X>,
+  options: IndependentDoubleIndexedProductOptions<K, J> = {}
+): DoubleIndexedIndependentProductResult<R, K, J, X> {
+  const outerList = Array.from(outerIndex);
+  const innerLookup = new Map<K, ReadonlyArray<J>>();
+  for (const outerKey of outerList) {
+    if (!innerLookup.has(outerKey)) {
+      innerLookup.set(outerKey, Array.from(innerIndex(outerKey)));
+    }
+  }
+  const toIndex = createDoubleIndexFactory<K, J>();
+  const index = enumerateDoubleIndex(
+    outerList,
+    (outerKey) => innerLookup.get(outerKey) ?? [],
+    toIndex
+  );
+  const family = independentIndexedProduct(
+    R,
+    index,
+    ({ outer, inner }) => coordinate(outer, inner),
+    options
+  );
+
+  const innerFamilies = new Map<K, ProjectiveFamily<R, J, X>>();
+  for (const outerKey of outerList) {
+    const innerList = innerLookup.get(outerKey) ?? [];
+    innerFamilies.set(
+      outerKey,
+      independentIndexedProduct(R, innerList, (innerValue) => coordinate(outerKey, innerValue))
+    );
+  }
+
+  return { family, infObj: createInfObj(family), toIndex, innerFamilies };
+}
+
+export function independentInfObj<R, J, X>(
+  R: CSRig<R>,
+  index: Iterable<J>,
+  coordinate: (idx: J) => Dist<R, X>,
+  options: IndependentIndexedProductOptions<J> = {}
+): InfObj<R, J, X> {
+  const family = independentIndexedProduct(R, index, coordinate, options);
+  return createInfObj(family);
+}
+
+export interface TensorKolmogorovProductResult<R, JL, XL, CL, JR, XR, CR> {
+  readonly family: ProjectiveFamily<R, TensorIndex<JL, JR>, XL | XR, TensorCarrier<CL, CR>>;
+  readonly infObj: InfObj<R, TensorIndex<JL, JR>, XL | XR, TensorCarrier<CL, CR>>;
+  readonly toLeft: (index: JL) => LeftIndex<JL>;
+  readonly toRight: (index: JR) => RightIndex<JR>;
+}
+
+export function tensorKolmogorovProducts<R, JL, XL, CL, JR, XR, CR>(
+  left: InfObj<R, JL, XL, CL>,
+  right: InfObj<R, JR, XR, CR>
+): TensorKolmogorovProductResult<R, JL, XL, CL, JR, XR, CR> {
+  const R = left.family.semiring;
+  if (right.family.semiring !== R) {
+    throw new Error("Tensor factors must share the same semiring.");
+  }
+
+  const leftIndices = Array.from(left.family.index);
+  const rightIndices = Array.from(right.family.index);
+  const factory = createDoubleIndexFactory<TensorSide, JL | JR>();
+  const toLeft = (index: JL): LeftIndex<JL> => factory("left", index) as LeftIndex<JL>;
+  const toRight = (index: JR): RightIndex<JR> => factory("right", index) as RightIndex<JR>;
+
+  const isLeftIndex = (index: TensorIndex<JL, JR>): index is LeftIndex<JL> => index.outer === "left";
+
+  const index: Iterable<TensorIndex<JL, JR>> = enumerateDoubleIndex<TensorSide, JL | JR>(
+    ["left", "right"],
+    (side) => (side === "left" ? (leftIndices as Iterable<JL | JR>) : (rightIndices as Iterable<JL | JR>)),
+    factory
+  ) as Iterable<TensorIndex<JL, JR>>;
+
+  const isZero = defaultIsZero(R);
+
+  const splitSubset = (finite: FiniteSubset<TensorIndex<JL, JR>>) => {
+    const leftSubset: JL[] = [];
+    const rightSubset: JR[] = [];
+    finite.forEach((index) => {
+      if (isLeftIndex(index)) {
+        leftSubset.push(index.inner);
+      } else {
+        rightSubset.push((index as RightIndex<JR>).inner);
+      }
+    });
+    return { leftSubset, rightSubset };
+  };
+
+  const splitSection = (
+    section: CylinderSection<TensorIndex<JL, JR>, XL | XR>
+  ): { left: CylinderSection<JL, XL>; right: CylinderSection<JR, XR> } => {
+    const leftSection = new Map<JL, XL>();
+    const rightSection = new Map<JR, XR>();
+    section.forEach((value, index) => {
+      if (isLeftIndex(index)) {
+        leftSection.set(index.inner, value as XL);
+      } else {
+        rightSection.set((index as RightIndex<JR>).inner, value as XR);
+      }
+    });
+    return {
+      left: leftSection as CylinderSection<JL, XL>,
+      right: rightSection as CylinderSection<JR, XR>,
+    };
+  };
+
+  const combineMarginals = (
+    leftSubset: FiniteSubset<JL>,
+    rightSubset: FiniteSubset<JR>
+  ): Dist<R, CylinderSection<TensorIndex<JL, JR>, XL | XR>> => {
+    const leftMarginal = left.family.marginal(leftSubset);
+    const rightMarginal = right.family.marginal(rightSubset);
+    const entries: Array<{ section: CylinderSection<TensorIndex<JL, JR>, XL | XR>; weight: R }> = [];
+
+    leftMarginal.w.forEach((leftWeight, leftSection) => {
+      rightMarginal.w.forEach((rightWeight, rightSection) => {
+        const weight = R.mul(leftWeight, rightWeight);
+        if (isZero(weight)) return;
+        const combined = new Map<TensorIndex<JL, JR>, XL | XR>();
+        leftSection.forEach((value, index) => {
+          combined.set(toLeft(index), value as XL);
+        });
+        rightSection.forEach((value, index) => {
+          combined.set(toRight(index), value as XR);
+        });
+        const existing = entries.find((candidate) => mapsEqual(candidate.section, combined));
+        if (existing) {
+          existing.weight = R.add(existing.weight, weight);
+        } else {
+          entries.push({ section: combined as CylinderSection<TensorIndex<JL, JR>, XL | XR>, weight });
+        }
+      });
+    });
+
+    const dist: Dist<R, CylinderSection<TensorIndex<JL, JR>, XL | XR>> = { R, w: new Map() };
+    if (entries.length === 0) {
+      dist.w.set(new Map(), R.one);
+      return dist;
+    }
+    for (const entry of entries) {
+      dist.w.set(entry.section, entry.weight);
+    }
+    return dist;
+  };
+
+  const marginal = (
+    finite: FiniteSubset<TensorIndex<JL, JR>>
+  ): Dist<R, CylinderSection<TensorIndex<JL, JR>, XL | XR>> => {
+    const { leftSubset, rightSubset } = splitSubset(finite);
+    return combineMarginals(leftSubset, rightSubset);
+  };
+
+  const project = (
+    carrier: TensorCarrier<CL, CR>,
+    finite: FiniteSubset<TensorIndex<JL, JR>>
+  ): CylinderSection<TensorIndex<JL, JR>, XL | XR> => {
+    const { leftSubset, rightSubset } = splitSubset(finite);
+    const [leftCarrier, rightCarrier] = carrier;
+    const section = new Map<TensorIndex<JL, JR>, XL | XR>();
+    const leftSection = left.family.project(leftCarrier, leftSubset);
+    leftSection.forEach((value, index) => {
+      section.set(toLeft(index), value as XL);
+    });
+    const rightSection = right.family.project(rightCarrier, rightSubset);
+    rightSection.forEach((value, index) => {
+      section.set(toRight(index), value as XR);
+    });
+    return section;
+  };
+
+  const extend =
+    left.family.extend && right.family.extend
+      ? (
+          finite: FiniteSubset<TensorIndex<JL, JR>>,
+          section: CylinderSection<TensorIndex<JL, JR>, XL | XR>
+        ): TensorCarrier<CL, CR> => {
+          const { leftSubset, rightSubset } = splitSubset(finite);
+          const { left: leftSection, right: rightSection } = splitSection(section);
+          const leftCarrier = left.family.extend!(leftSubset, leftSection);
+          const rightCarrier = right.family.extend!(rightSubset, rightSection);
+          return [leftCarrier, rightCarrier] as const;
+        }
+      : undefined;
+
+  const update =
+    left.family.update && right.family.update
+      ? (
+          carrier: TensorCarrier<CL, CR>,
+          section: CylinderSection<TensorIndex<JL, JR>, XL | XR>
+        ): TensorCarrier<CL, CR> => {
+          const { left: leftSection, right: rightSection } = splitSection(section);
+          const nextLeft = left.family.update!(carrier[0], leftSection);
+          const nextRight = right.family.update!(carrier[1], rightSection);
+          return [nextLeft, nextRight] as const;
+        }
+      : undefined;
+
+  const kolmogorov =
+    left.family.kolmogorov && right.family.kolmogorov
+      ? {
+          explanation: [left.family.kolmogorov.explanation, right.family.kolmogorov.explanation]
+            .filter(Boolean)
+            .join("; ") || undefined,
+          check: (finite: FiniteSubset<TensorIndex<JL, JR>>, larger: FiniteSubset<TensorIndex<JL, JR>>) => {
+            const { leftSubset: leftFinite, rightSubset: rightFinite } = splitSubset(finite);
+            const { leftSubset: leftLarger, rightSubset: rightLarger } = splitSubset(larger);
+            const leftOk = left.family.kolmogorov!.check(leftFinite, leftLarger);
+            const rightOk = right.family.kolmogorov!.check(rightFinite, rightLarger);
+            return leftOk && rightOk;
+          },
+        }
+      : undefined;
+
+  const combineCountability = () => {
+    const leftWitness = left.family.countability;
+    const rightWitness = right.family.countability;
+    if (!leftWitness && !rightWitness) return undefined;
+    const kind: CountabilityKind =
+      leftWitness?.kind === "countablyInfinite" || rightWitness?.kind === "countablyInfinite"
+        ? "countablyInfinite"
+        : "finite";
+    const enumerate = () => ({
+      [Symbol.iterator]: function* () {
+        if (leftWitness) {
+          for (const index of leftWitness.enumerate()) yield toLeft(index);
+        } else {
+          for (const index of leftIndices) yield toLeft(index);
+        }
+        if (rightWitness) {
+          for (const index of rightWitness.enumerate()) yield toRight(index);
+        } else {
+          for (const index of rightIndices) yield toRight(index);
+        }
+      },
+    });
+    const sample: Array<TensorIndex<JL, JR>> = [];
+    leftWitness?.sample.forEach((index) => sample.push(toLeft(index)));
+    rightWitness?.sample.forEach((index) => sample.push(toRight(index)));
+    const reasonParts: string[] = [];
+    if (leftWitness?.reason) reasonParts.push(`left: ${leftWitness.reason}`);
+    if (rightWitness?.reason) reasonParts.push(`right: ${rightWitness.reason}`);
+    const size =
+      leftWitness?.size !== undefined && rightWitness?.size !== undefined
+        ? (leftWitness.size ?? 0) + (rightWitness.size ?? 0)
+        : leftWitness?.size ?? rightWitness?.size;
+    return {
+      kind,
+      enumerate,
+      sample,
+      reason: reasonParts.length > 0 ? reasonParts.join("; ") : undefined,
+      size,
+    } as CountabilityWitness<TensorIndex<JL, JR>>;
+  };
+
+  const combineMeasurability = () => {
+    const leftWitness = left.family.measurability;
+    const rightWitness = right.family.measurability;
+    if (!leftWitness && !rightWitness) return undefined;
+    const coordinates: Array<CoordinateMeasurability<TensorIndex<JL, JR>>> = [];
+    leftWitness?.coordinates?.forEach((coordinate) => {
+      coordinates.push({
+        index: toLeft(coordinate.index),
+        sigmaAlgebra: coordinate.sigmaAlgebra,
+        witness: coordinate.witness,
+        standardBorel: coordinate.standardBorel,
+      });
+    });
+    rightWitness?.coordinates?.forEach((coordinate) => {
+      coordinates.push({
+        index: toRight(coordinate.index),
+        sigmaAlgebra: coordinate.sigmaAlgebra,
+        witness: coordinate.witness,
+        standardBorel: coordinate.standardBorel,
+      });
+    });
+    const kind: MeasurabilityKind = (() => {
+      if (leftWitness?.kind === "standardBorel" && rightWitness?.kind === "standardBorel") return "standardBorel";
+      if (leftWitness?.kind === "measurable" && rightWitness?.kind === "measurable") return "measurable";
+      return leftWitness?.kind ?? rightWitness?.kind ?? "unknown";
+    })();
+    const reasonParts: string[] = [];
+    if (leftWitness?.reason) reasonParts.push(`left: ${leftWitness.reason}`);
+    if (rightWitness?.reason) reasonParts.push(`right: ${rightWitness.reason}`);
+    return {
+      kind,
+      coordinates: coordinates.length > 0 ? coordinates : undefined,
+      reason: reasonParts.length > 0 ? reasonParts.join("; ") : undefined,
+    } as MeasurabilityWitness<TensorIndex<JL, JR>>;
+  };
+
+  const leftPositivity = left.positivity ?? left.family.positivity;
+  const rightPositivity = right.positivity ?? right.family.positivity;
+  const positivity =
+    leftPositivity?.kind === "positive" && rightPositivity?.kind === "positive"
+      ? (() => {
+          const seen = new Set<TensorIndex<JL, JR>>();
+          const indices: TensorIndex<JL, JR>[] = [];
+          const add = (index: TensorIndex<JL, JR>) => {
+            if (!seen.has(index)) {
+              seen.add(index);
+              indices.push(index);
+            }
+          };
+          leftPositivity.indices?.forEach((index) => add(toLeft(index)));
+          rightPositivity.indices?.forEach((index) => add(toRight(index)));
+          return {
+            kind: "positive" as const,
+            indices: indices.length > 0 ? indices : undefined,
+            reason: [leftPositivity.reason, rightPositivity.reason].filter(Boolean).join("; ") || undefined,
+          } as PositivityWitness<TensorIndex<JL, JR>>;
+        })()
+      : undefined;
+
+  const family: ProjectiveFamily<R, TensorIndex<JL, JR>, XL | XR, TensorCarrier<CL, CR>> = {
+    semiring: R,
+    index,
+    coordinate: (index) =>
+      (isLeftIndex(index)
+        ? (left.family.coordinate(index.inner) as Dist<R, XL | XR>)
+        : (right.family.coordinate((index as RightIndex<JR>).inner) as Dist<R, XL | XR>)),
+    marginal,
+    project,
+    extend,
+    update,
+    kolmogorov,
+    countability: combineCountability(),
+    measurability: combineMeasurability(),
+    positivity,
+  };
+
+  const infObj = createInfObj(family);
+  return { family, infObj, toLeft, toRight };
+}
+
+export interface KolmogorovTest<J> {
+  readonly finite: FiniteSubset<J>;
+  readonly larger: FiniteSubset<J>;
+}
+
+export interface KolmogorovConsistencySummary<J> {
+  readonly ok: boolean;
+  readonly failures: KolmogorovTest<J>[];
+  readonly countable: boolean;
+  readonly witness?: CountabilityWitness<J>;
+  readonly measurable: boolean;
+  readonly measurability?: MeasurabilityWitness<J>;
+  readonly standardBorel: boolean;
+}
+
+export function checkKolmogorovConsistency<R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>,
+  tests: ReadonlyArray<KolmogorovTest<J>>
+): KolmogorovConsistencySummary<J> {
+  const failures: KolmogorovTest<J>[] = [];
+  const R = family.semiring;
+
+  for (const test of tests) {
+    const { finite, larger } = test;
+    if (!isSubset(finite, larger)) {
+      failures.push(test);
+      continue;
+    }
+
+    if (family.kolmogorov) {
+      if (!family.kolmogorov.check(finite, larger)) failures.push(test);
+      continue;
+    }
+
+    const small = family.marginal(finite);
+    const restricted = pushforwardCylinder(R, family.marginal(larger), finite);
+    if (!equalDist(R, small, restricted)) failures.push(test);
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    countable: isCountableIndex(family),
+    witness: family.countability,
+    measurable: hasMeasurabilityWitness(family),
+    measurability: family.measurability,
+    standardBorel: isStandardBorelFamily(family),
+  };
+}
+
+export function applyPatch<R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>,
+  carrier: Carrier,
+  patch: CylinderSection<J, X>
+): Carrier {
+  if (!family.update) {
+    throw new Error("Projective family does not expose finite-update adapter");
+  }
+  return family.update(carrier, patch);
+}
+
+const collectUnion = <J>(subsets: ReadonlyArray<FiniteSubset<J>>): FiniteSubset<J> => {
+  const keys: J[] = [];
+  const seen = new Set<unknown>();
+  for (const subset of subsets) {
+    for (const index of subset) {
+      if (!seen.has(index)) {
+        seen.add(index);
+        keys.push(index);
+      }
+    }
+  }
+  return keys;
+};
+
+export type KolmogorovExtensionOutcome<R, J, X, Carrier> =
+  | { ok: true; baseSubset: FiniteSubset<J>; measure: Dist<R, Carrier> }
+  | { ok: false; reason: string };
+
+export function kolmogorovExtensionMeasure<R, J, X, Carrier>(
+  family: ProjectiveFamily<R, J, X, Carrier>,
+  subsets: ReadonlyArray<FiniteSubset<J>>
+): KolmogorovExtensionOutcome<R, J, X, Carrier> {
+  if (!family.extend) {
+    return { ok: false, reason: "Projective family does not supply an extension builder" };
+  }
+
+  const baseSubset = subsets.length === 0 ? [] : collectUnion(subsets);
+  const marginal = family.marginal(baseSubset);
+  const measure = map(marginal, (section) => family.extend!(baseSubset, section));
+  return { ok: true, baseSubset, measure };
+}
+
+export interface DeterministicKolmogorovProjection<R, J, X, Carrier> {
+  readonly index: J;
+  readonly base: (carrier: Carrier) => X;
+  readonly kernel: KernelR<R, Carrier, X>;
+}
+
+export interface DeterministicProductComponentInput<A, J, X> {
+  readonly index: J;
+  readonly arrow: FinMarkov<A, X>;
+  readonly witness: MarkovComonoidWitness<X>;
+  readonly base?: (input: A) => X;
+  readonly label?: string;
+}
+
+export interface DeterministicMediatorCandidate<R, A, Carrier> {
+  readonly base: (input: A) => Carrier;
+  readonly kernel?: KernelR<R, A, Carrier>;
+  readonly label?: string;
+}
+
+export interface DeterministicComponent<A, J, X> {
+  readonly index: J;
+  readonly base: (input: A) => X;
+}
+
+export interface DeterministicKolmogorovFactorizationFailure<J> {
+  readonly index?: J;
+  readonly reason: string;
+}
+
+export interface DeterministicKolmogorovFactorization<R, A, J, X, Carrier> {
+  readonly ok: boolean;
+  readonly subset: FiniteSubset<J>;
+  readonly base?: (input: A) => Carrier;
+  readonly kernel?: KernelR<R, A, Carrier>;
+  readonly details: string;
+  readonly failures: ReadonlyArray<DeterministicKolmogorovFactorizationFailure<J>>;
+}
+
+export interface DeterministicKolmogorovProductWitness<R, J, X, Carrier> {
+  readonly infObj: InfObj<R, J, X, Carrier>;
+  readonly indices: Iterable<J>;
+  readonly projection: (index: J) => DeterministicKolmogorovProjection<R, J, X, Carrier>;
+  readonly factor: <A>(
+    components: ReadonlyArray<DeterministicComponent<A, J, X>>
+  ) => DeterministicKolmogorovFactorization<R, A, J, X, Carrier>;
+  readonly restrict: (subset: Iterable<J>) => DeterministicKolmogorovProductWitness<R, J, X, Carrier>;
+}
+
+const describeIndices = <J>(subset: FiniteSubset<J>): string =>
+  subset.length === 0 ? "∅" : subset.map((index) => String(index)).join(", ");
+
+export function buildDeterministicKolmogorovProductWitness<R, J, X, Carrier>(
+  infObj: InfObj<R, J, X, Carrier>
+): DeterministicKolmogorovProductWitness<R, J, X, Carrier> {
+  const { family } = infObj;
+  const cache = new Map<J, DeterministicKolmogorovProjection<R, J, X, Carrier>>();
+
+  const projection = (index: J): DeterministicKolmogorovProjection<R, J, X, Carrier> => {
+    let entry = cache.get(index);
+    if (!entry) {
+      const base = infObj.deterministicProjection(index);
+      entry = {
+        index,
+        base,
+        kernel: asDeterministicKernel(family.semiring, base),
+      };
+      cache.set(index, entry);
+    }
+    return entry;
+  };
+
+  const factor = <A>(
+    components: ReadonlyArray<DeterministicComponent<A, J, X>>
+  ): DeterministicKolmogorovFactorization<R, A, J, X, Carrier> => {
+    const subsetList: J[] = [];
+    const failures: DeterministicKolmogorovFactorizationFailure<J>[] = [];
+    const seen = new Set<unknown>();
+
+    for (const component of components) {
+      if (seen.has(component.index as unknown)) {
+        failures.push({
+          index: component.index,
+          reason: `Duplicate component for index ${String(component.index)}`,
+        });
+      } else {
+        seen.add(component.index as unknown);
+        subsetList.push(component.index);
+      }
+    }
+
+    const subset = subsetList.slice() as FiniteSubset<J>;
+
+    if (failures.length > 0) {
+      return {
+        ok: false,
+        subset,
+        details: `${failures.length} duplicate index${failures.length === 1 ? "" : "es"} prevented deterministic factorization.`,
+        failures,
+      };
+    }
+
+    const extend = family.extend;
+    if (!extend) {
+      const reason = "Projective family does not supply an extension builder";
+      return {
+        ok: false,
+        subset,
+        details: reason,
+        failures: [{ reason }],
+      };
+    }
+
+    if (subset.length === 0) {
+      let constant: Carrier;
+      try {
+        constant = extend([], new Map() as CylinderSection<J, X>);
+      } catch (error) {
+        const reason = `Extension failed for the empty subset: ${(error as Error).message}`;
+        return {
+          ok: false,
+          subset,
+          details: reason,
+          failures: [{ reason }],
+        };
+      }
+
+      const base = () => constant;
+      return {
+        ok: true,
+        subset,
+        base,
+        kernel: asDeterministicKernel(family.semiring, base),
+        details: "Empty index tuple yields the terminal deterministic mediator.",
+        failures,
+      };
+    }
+
+    const subsetDescription = describeIndices(subset);
+
+    const base = (input: A): Carrier => {
+      const section = new Map<J, X>();
+      for (const component of components) {
+        section.set(component.index, component.base(input));
+      }
+      try {
+        return extend(subset, section as CylinderSection<J, X>);
+      } catch (error) {
+        throw new Error(
+          `Kolmogorov extension failed for subset {${subsetDescription}}: ${(error as Error).message}`
+        );
+      }
+    };
+
+    return {
+      ok: true,
+      subset,
+      base,
+      kernel: asDeterministicKernel(family.semiring, base),
+      details: `Constructed deterministic mediator over indices {${subsetDescription}}.`,
+      failures,
+    };
+  };
+
+  return {
+    infObj,
+    indices: family.index,
+    projection,
+    factor,
+    restrict: (subset) => buildDeterministicKolmogorovProductWitness(restrictInfObj(infObj, subset)),
+  };
+}
+
+export function deterministicBooleanValue<R>(R: CSRig<R>, dist: Dist<R, boolean>): boolean {
+  const isZero = defaultIsZero(R);
+  let outcome: boolean | null = null;
+  dist.w.forEach((weight, key) => {
+    if (isZero(weight)) return;
+    if (outcome === null) {
+      outcome = key;
+    } else if (outcome !== key) {
+      throw new Error("Distribution is not deterministic over booleans");
+    }
+  });
+  return outcome ?? false;
+}
+
+export interface KolmogorovZeroOneLawWitness<R, A, J, X, Carrier, XDet = unknown, Tail = unknown> {
+  readonly product: DeterministicKolmogorovProductWitness<R, J, X, Carrier>;
+  readonly domain: MarkovComonoidWitness<A>;
+  readonly measure: Dist<R, Carrier>;
+  readonly tailEvent: KernelR<R, Carrier, boolean>;
+  readonly determinismLemma?: DeterminismLemmaWitness<A, XDet, Tail>;
+  readonly independence?: MarkovConditionalWitness<A>;
+  readonly tailConditional?: MarkovConditionalWitness<A>;
+  readonly components?: ReadonlyArray<DeterministicProductComponentInput<A, J, X>>;
+  readonly mediator?: DeterministicMediatorCandidate<R, A, Carrier>;
+}
+
+export interface HewittSavageZeroOneLawWitness<R, A, J, X, Carrier, XDet = unknown, Tail = unknown>
+  extends KolmogorovZeroOneLawWitness<R, A, J, X, Carrier, XDet, Tail> {
+  readonly permutations: ReadonlyArray<(carrier: Carrier) => Carrier>;
+}

--- a/markov-monoidal.ts
+++ b/markov-monoidal.ts
@@ -4,6 +4,7 @@
 import type { CSRig } from "./semiring-utils";
 import type { Dist } from "./dist";
 import { dirac, bind, map, strength } from "./dist";
+export { independentIndexedProduct, independentInfObj } from "./markov-infinite";
 
 // Stable key for Map (only used if you want string keys elsewhere)
 const pair = <X, Y>(x: X, y: Y): [X, Y] => [x, y] as [X, Y];

--- a/ring.ts
+++ b/ring.ts
@@ -20,6 +20,16 @@ export const RingReal: Ring<number> = {
   sub: (a,b) => a - b,
 }
 
+export const RingInteger: Ring<bigint> = {
+  add: (a, b) => a + b,
+  zero: 0n,
+  mul: (a, b) => a * b,
+  one: 1n,
+  eq: (a, b) => a === b,
+  neg: (a) => -a,
+  sub: (a, b) => a - b,
+}
+
 // Elementwise matrix addition (same shape)
 export const matAdd =
   <R>(Rng: Ring<R>) =>

--- a/semicartesian-infinite-product.ts
+++ b/semicartesian-infinite-product.ts
@@ -1,0 +1,208 @@
+// 🔮 BEGIN_MATH: SemicartesianInfiniteTensorProduct
+// 📝 Brief: Capture infinite tensor products in semicartesian symmetric monoidal categories.
+// 🏗️ Domain: Category theory / semicartesian symmetric monoidal structure
+// 🔗 Integration: Provides reusable witnesses and oracles for infinite cones and their universal property
+// 📋 Plan:
+//   1. Describe the finite-subset indexing data and cone legs for semicartesian diagrams.
+//   2. Expose a product witness interface bundling projections and factorization builders.
+//   3. Implement compatibility and universal-property oracles with diagnostic reporting.
+
+export type FiniteSubset<J> = ReadonlyArray<J>;
+
+export interface SemicartesianTensorDiagram<J, Obj, Mor> {
+  readonly index: Iterable<J>;
+  readonly tensor: (subset: FiniteSubset<J>) => Obj;
+  readonly restriction: (larger: FiniteSubset<J>, smaller: FiniteSubset<J>) => Mor;
+  readonly compose: (first: Mor, second: Mor) => Mor;
+  readonly equal: (a: Mor, b: Mor) => boolean;
+  readonly describeSubset?: (subset: FiniteSubset<J>) => string;
+  readonly describeMorphism?: (morphism: Mor) => string;
+}
+
+export interface SemicartesianCone<J, Obj, Mor> {
+  readonly apex: Obj;
+  readonly leg: (subset: FiniteSubset<J>) => Mor;
+  readonly label?: string;
+  readonly mediatorCandidates?: ReadonlyArray<{ morphism: Mor; label?: string }>;
+}
+
+export interface SemicartesianFactorization<Mor> {
+  readonly mediator: Mor;
+  readonly details?: string;
+}
+
+export interface SemicartesianProductWitness<J, Obj, Mor> {
+  readonly object: Obj;
+  readonly diagram: SemicartesianTensorDiagram<J, Obj, Mor>;
+  readonly projection: (subset: FiniteSubset<J>) => Mor;
+  readonly factor: (cone: SemicartesianCone<J, Obj, Mor>) => SemicartesianFactorization<Mor>;
+  readonly label?: string;
+}
+
+export interface SubsetRestriction<J> {
+  readonly larger: FiniteSubset<J>;
+  readonly smaller: FiniteSubset<J>;
+  readonly label?: string;
+}
+
+const subsetKey = <J>(subset: FiniteSubset<J>): string =>
+  subset.map((item) => `${item}`).join(",");
+
+const describeSubset = <J>(
+  diagram: SemicartesianTensorDiagram<J, unknown, unknown>,
+  subset: FiniteSubset<J>,
+): string => diagram.describeSubset?.(subset) ?? (subset.length ? subsetKey(subset) : "∅");
+
+const describeMorphism = <J, Mor>(
+  diagram: SemicartesianTensorDiagram<J, unknown, Mor>,
+  morphism: Mor,
+): string => diagram.describeMorphism?.(morphism) ?? "morphism";
+
+const isSubset = <J>(smaller: FiniteSubset<J>, larger: FiniteSubset<J>): boolean => {
+  const lookup = new Set(larger as Iterable<J>);
+  for (const item of smaller) {
+    if (!lookup.has(item)) return false;
+  }
+  return true;
+};
+
+export interface SemicartesianConeFailure<J> {
+  readonly larger: FiniteSubset<J>;
+  readonly smaller: FiniteSubset<J>;
+  readonly reason: string;
+}
+
+export interface SemicartesianConeResult<J> {
+  readonly holds: boolean;
+  readonly details: string;
+  readonly failures: ReadonlyArray<SemicartesianConeFailure<J>>;
+}
+
+export function checkSemicartesianProductCone<J, Obj, Mor>(
+  product: SemicartesianProductWitness<J, Obj, Mor>,
+  restrictions: ReadonlyArray<SubsetRestriction<J>>,
+): SemicartesianConeResult<J> {
+  const { diagram } = product;
+  const failures: Array<SemicartesianConeFailure<J>> = [];
+
+  for (const restriction of restrictions) {
+    const { larger, smaller } = restriction;
+    if (!isSubset(smaller, larger)) {
+      failures.push({
+        larger,
+        smaller,
+        reason: `${describeSubset(diagram, smaller)} is not contained in ${describeSubset(diagram, larger)}.`,
+      });
+      continue;
+    }
+
+    const composed = diagram.compose(product.projection(larger), diagram.restriction(larger, smaller));
+    const expected = product.projection(smaller);
+    if (!diagram.equal(composed, expected)) {
+      failures.push({
+        larger,
+        smaller,
+        reason: `Projection ${describeSubset(diagram, smaller)} failed compatibility through ${describeSubset(diagram, larger)}.`,
+      });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All ${restrictions.length} projection compatibilities succeeded.`
+    : `${failures.length} projection compatibility check${failures.length === 1 ? "" : "s"} failed.`;
+
+  return { holds, details, failures };
+}
+
+export interface SemicartesianMediatorSummary<J, Mor> {
+  readonly coneLabel?: string;
+  readonly mediator: Mor;
+  readonly details?: string;
+  readonly subsets: ReadonlyArray<FiniteSubset<J>>;
+}
+
+export interface SemicartesianUniversalFailure<J, Mor> {
+  readonly coneLabel?: string;
+  readonly subset?: FiniteSubset<J>;
+  readonly reason: string;
+  readonly witness?: Mor;
+}
+
+export interface SemicartesianUniversalResult<J, Mor> {
+  readonly holds: boolean;
+  readonly details: string;
+  readonly mediators: ReadonlyArray<SemicartesianMediatorSummary<J, Mor>>;
+  readonly failures: ReadonlyArray<SemicartesianUniversalFailure<J, Mor>>;
+}
+
+export function checkSemicartesianUniversalProperty<J, Obj, Mor>(
+  product: SemicartesianProductWitness<J, Obj, Mor>,
+  cones: ReadonlyArray<SemicartesianCone<J, Obj, Mor>>,
+  subsets: ReadonlyArray<FiniteSubset<J>>,
+): SemicartesianUniversalResult<J, Mor> {
+  const { diagram } = product;
+  const failures: Array<SemicartesianUniversalFailure<J, Mor>> = [];
+  const mediators: Array<SemicartesianMediatorSummary<J, Mor>> = [];
+
+  for (const cone of cones) {
+    let factorization: SemicartesianFactorization<Mor>;
+    try {
+      factorization = product.factor(cone);
+    } catch (error) {
+      failures.push({
+        coneLabel: cone.label,
+        reason: `Factorization threw: ${(error as Error).message}`,
+      });
+      continue;
+    }
+
+    const coneLabel = cone.label;
+    mediators.push({ coneLabel, mediator: factorization.mediator, details: factorization.details, subsets });
+
+    for (const subset of subsets) {
+      const expected = cone.leg(subset);
+      const projected = diagram.compose(factorization.mediator, product.projection(subset));
+      if (!diagram.equal(projected, expected)) {
+        failures.push({
+          coneLabel,
+          subset,
+          reason: `Mediator failed to reproduce leg on ${describeSubset(diagram, subset)}.`,
+          witness: projected,
+        });
+      }
+    }
+
+    if (cone.mediatorCandidates) {
+      for (const candidate of cone.mediatorCandidates) {
+        let satisfies = true;
+        for (const subset of subsets) {
+          const candidateProjection = diagram.compose(candidate.morphism, product.projection(subset));
+          if (!diagram.equal(candidateProjection, cone.leg(subset))) {
+            satisfies = false;
+            break;
+          }
+        }
+        if (satisfies && !diagram.equal(candidate.morphism, factorization.mediator)) {
+          failures.push({
+            coneLabel,
+            reason: `Candidate mediator ${candidate.label ?? describeMorphism(diagram, candidate.morphism)} violates uniqueness.`,
+            witness: candidate.morphism,
+          });
+        }
+      }
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All ${cones.length} cones factored uniquely across ${subsets.length} subset tests.`
+    : `${failures.length} universal-property check${failures.length === 1 ? "" : "s"} failed.`;
+
+  return { holds, details, mediators, failures };
+}
+
+// ✅ END_MATH: SemicartesianInfiniteTensorProduct
+// 🔮 Oracles: checkSemicartesianProductCone, checkSemicartesianUniversalProperty
+// 📜 Laws: Infinite tensor products in semicartesian symmetric monoidal categories
+// 🧪 Tests: law.SemicartesianInfiniteProduct.spec.ts exercising compatibility, factorization, and uniqueness diagnostics

--- a/semicartesian-structure.ts
+++ b/semicartesian-structure.ts
@@ -1,0 +1,113 @@
+// 🔮 BEGIN_MATH: SemicartesianInitialUnit
+// 📝 Brief: Capture semicartesian structure induced by an initial tensor unit
+// 🏗️ Domain: Category theory / symmetric monoidal categories
+// 🔗 Integration: Provides reusable interface/oracle for categories exposing initial tensor units
+// 📋 Plan:
+//   1. Define witnesses for initial objects tied to the tensor unit.
+//   2. Package semicartesian structure derived from those witnesses.
+//   3. Implement an oracle that validates uniqueness expectations with optional counterexamples.
+
+export interface InitialObjectWitness<O, M> {
+  readonly object: O;
+  readonly morphismTo: (target: O) => M;
+  readonly isCanonical: (target: O, candidate: M) => boolean;
+  readonly describe?: (target: O) => string;
+}
+
+export interface SemicartesianStructure<O, M> {
+  readonly unit: O;
+  readonly globalElement: (target: O) => M;
+}
+
+export interface InitialUnitSemicartesianData<O, M> {
+  readonly unit: O;
+  readonly witness: InitialObjectWitness<O, M>;
+}
+
+export interface InitialArrowSample<O, M> {
+  readonly target: O;
+  readonly candidate: M;
+  readonly shouldHold: boolean;
+  readonly label?: string;
+}
+
+export interface InitialUnitSemicartesianResult<O, M> {
+  readonly holds: boolean;
+  readonly witness: SemicartesianStructure<O, M>;
+  readonly details: string;
+  readonly failures: ReadonlyArray<{ target: O; reason: string }>;
+  readonly sampleResults: ReadonlyArray<{
+    readonly label?: string;
+    readonly target: O;
+    readonly expected: boolean;
+    readonly actual: boolean;
+  }>;
+}
+
+export function deriveSemicartesianFromInitial<O, M>(
+  data: InitialUnitSemicartesianData<O, M>
+): SemicartesianStructure<O, M> {
+  const { unit, witness } = data;
+  if (unit !== witness.object) {
+    throw new Error("Initial witness must reference the tensor unit object");
+  }
+  return {
+    unit,
+    globalElement: witness.morphismTo,
+  };
+}
+
+export function checkInitialUnitSemicartesian<O, M>(
+  data: InitialUnitSemicartesianData<O, M>,
+  targets: ReadonlyArray<O>,
+  samples: ReadonlyArray<InitialArrowSample<O, M>> = []
+): InitialUnitSemicartesianResult<O, M> {
+  const structure = deriveSemicartesianFromInitial(data);
+  const failures: Array<{ target: O; reason: string }> = [];
+  const sampleResults: Array<{
+    label?: string;
+    target: O;
+    expected: boolean;
+    actual: boolean;
+  }> = [];
+
+  for (const target of targets) {
+    const arrow = structure.globalElement(target);
+    const canonical = data.witness.isCanonical(target, arrow);
+    if (!canonical) {
+      const description = data.witness.describe?.(target) ?? "canonical arrow";
+      failures.push({ target, reason: `${description} failed uniqueness validation` });
+    }
+  }
+
+  for (const sample of samples) {
+    const actual = data.witness.isCanonical(sample.target, sample.candidate);
+    sampleResults.push({
+      label: sample.label,
+      target: sample.target,
+      expected: sample.shouldHold,
+      actual,
+    });
+    if (actual !== sample.shouldHold) {
+      const description = sample.label ?? data.witness.describe?.(sample.target) ?? "sample";
+      const expectation = sample.shouldHold ? "canonical" : "non-canonical";
+      failures.push({
+        target: sample.target,
+        reason: `${description} expected to be ${expectation} but oracle returned ${actual}`,
+      });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All canonical arrows from the unit satisfied initial-object uniqueness across ${targets.length} targets.`
+    : `${failures.length} semicartesian checks failed.`;
+
+  return { holds, witness: structure, details, failures, sampleResults };
+}
+
+// ✅ END_MATH: SemicartesianInitialUnit
+// 🔮 Oracles: checkInitialUnitSemicartesian
+// 📜 Laws: Initial tensor unit induces semicartesian structure
+// 🧪 Tests: Validated via dedicated law spec exercising canonical and non-canonical samples
+// 📊 Coverage: Integration through reusable semicartesian witness builder

--- a/setmult-category.ts
+++ b/setmult-category.ts
@@ -1,0 +1,419 @@
+// 🔮 BEGIN_MATH: SetMultCategory
+// 📝 Brief: Multi-valued maps between sets viewed as a semicartesian category.
+// 🏗️ Domain: Category theory / Set-based multivalued morphisms
+// 🔗 Integration: Bridges to existing Markov/deterministic tooling and infinite-product builders.
+// 📋 Plan:
+//   1. Model Set-based objects together with equality/pretty-print hooks.
+//   2. Implement multi-valued morphisms with identity, composition, tensor, and copy/discard structure.
+//   3. Provide adapters to/from deterministic maps and finite stochastic kernels.
+
+import type { Eq, Fin, Kernel, Pair, Show } from "./markov-category";
+import { byRefEq, defaultShow, deterministic } from "./markov-category";
+import type { CountabilityWitness } from "./markov-infinite";
+
+export interface SetMultObj<T> {
+  readonly eq: Eq<T>;
+  readonly show: Show<T>;
+  readonly label?: string;
+  readonly samples?: ReadonlyArray<T>;
+}
+
+export const createSetMultObj = <T>(options: {
+  readonly eq?: Eq<T>;
+  readonly show?: Show<T>;
+  readonly label?: string;
+  readonly samples?: ReadonlyArray<T>;
+} = {}): SetMultObj<T> => ({
+  eq: options.eq ?? byRefEq<T>(),
+  show: options.show ?? defaultShow,
+  label: options.label,
+  samples: options.samples,
+});
+
+export const setMultObjFromFin = <T>(fin: Fin<T>, label?: string): SetMultObj<T> => ({
+  eq: fin.eq,
+  show: fin.show ?? defaultShow,
+  label,
+  samples: fin.elems,
+});
+
+export type SetMulti<A, B> = (a: A) => ReadonlySet<B>;
+
+const normalizeFibre = <T>(values: Iterable<T>, eq: Eq<T>, show: Show<T>): ReadonlySet<T> => {
+  const unique: T[] = [];
+  for (const value of values) {
+    if (!unique.some((candidate) => eq(candidate, value))) {
+      unique.push(value);
+    }
+  }
+  unique.sort((a, b) => show(a).localeCompare(show(b)));
+  return new Set(unique);
+};
+
+export const singletonFibre = <T>(value: T, eq: Eq<T>, show: Show<T>): ReadonlySet<T> =>
+  normalizeFibre([value], eq, show);
+
+export const fromTable = <A, B>(
+  domain: ReadonlyArray<A>,
+  build: (value: A) => Iterable<B>,
+  codomain: SetMultObj<B>,
+): SetMulti<A, B> => {
+  const fibres = new Map<A, ReadonlySet<B>>();
+  for (const value of domain) {
+    const fibre = normalizeFibre(build(value), codomain.eq, codomain.show);
+    if (fibre.size === 0) {
+      throw new Error("SetMulti fibres must be non-empty");
+    }
+    fibres.set(value, fibre);
+  }
+  return (input: A) => {
+    const existing = fibres.get(input);
+    if (!existing) throw new Error("Input outside of SetMulti table");
+    return existing;
+  };
+};
+
+export const composeSetMulti = <A, B, C>(
+  codomain: SetMultObj<C>,
+  f: SetMulti<A, B>,
+  g: SetMulti<B, C>,
+): SetMulti<A, C> => {
+  const { eq, show } = codomain;
+  return (input: A) => {
+    const combined: C[] = [];
+    for (const intermediate of f(input)) {
+      const fibre = g(intermediate);
+      if (fibre.size === 0) {
+        throw new Error("SetMulti composition encountered an empty fibre");
+      }
+      for (const value of fibre) {
+        if (!combined.some((candidate) => eq(candidate, value))) {
+          combined.push(value);
+        }
+      }
+    }
+    if (combined.length === 0) {
+      throw new Error("SetMulti composition produced an empty fibre");
+    }
+    combined.sort((a, b) => show(a).localeCompare(show(b)));
+    return new Set(combined);
+  };
+};
+
+export const idSetMulti = <T>(obj: SetMultObj<T>): SetMulti<T, T> =>
+  (value) => singletonFibre(value, obj.eq, obj.show);
+
+export const pairEq = <A, B>(left: Eq<A>, right: Eq<B>): Eq<Pair<A, B>> =>
+  (a, b) => left(a[0], b[0]) && right(a[1], b[1]);
+
+export const pairShow = <A, B>(left: Show<A>, right: Show<B>): Show<Pair<A, B>> =>
+  ([a, b]) => `(${left(a)}, ${right(b)})`;
+
+export const tensorSetMultObj = <A, B>(
+  left: SetMultObj<A>,
+  right: SetMultObj<B>,
+): SetMultObj<Pair<A, B>> => ({
+  eq: pairEq(left.eq, right.eq),
+  show: pairShow(left.show, right.show),
+  label: left.label && right.label ? `${left.label} ⊗ ${right.label}` : undefined,
+});
+
+const cartesianProduct = <A, B>(
+  left: Iterable<A>,
+  right: Iterable<B>,
+  eq: Eq<Pair<A, B>>,
+  show: Show<Pair<A, B>>,
+): ReadonlySet<Pair<A, B>> => {
+  const pairs: Array<Pair<A, B>> = [];
+  for (const a of left) {
+    for (const b of right) {
+      const pair: Pair<A, B> = [a, b];
+      if (!pairs.some((candidate) => eq(candidate, pair))) {
+        pairs.push(pair);
+      }
+    }
+  }
+  pairs.sort((x, y) => show(x).localeCompare(show(y)));
+  return new Set(pairs);
+};
+
+export const tensorSetMulti = <A, B, C, D>(
+  codomain: SetMultObj<Pair<C, D>>,
+  f: SetMulti<A, C>,
+  g: SetMulti<B, D>,
+): SetMulti<Pair<A, B>, Pair<C, D>> => ([a, b]) => {
+  const fibre = cartesianProduct(f(a), g(b), codomain.eq, codomain.show);
+  if (fibre.size === 0) {
+    throw new Error("Tensor of SetMulti morphisms produced an empty fibre");
+  }
+  return fibre;
+};
+
+export type SetMultUnit = { readonly kind: "unit" };
+export const setMultUnit: SetMultUnit = { kind: "unit" };
+
+export const setMultUnitObj: SetMultObj<SetMultUnit> = createSetMultObj({
+  eq: (a, b) => a.kind === b.kind,
+  show: () => "⋆",
+  label: "⋆",
+  samples: [setMultUnit],
+});
+
+export const copySetMulti = <T>(obj: SetMultObj<T>): SetMulti<T, Pair<T, T>> =>
+  (value) => singletonFibre([value, value], pairEq(obj.eq, obj.eq), pairShow(obj.show, obj.show));
+
+export const discardSetMulti = <T>(): SetMulti<T, SetMultUnit> =>
+  () => singletonFibre(setMultUnit, setMultUnitObj.eq, setMultUnitObj.show);
+
+export interface DeterministicSetMultWitness<A, B> {
+  readonly domain: SetMultObj<A>;
+  readonly codomain: SetMultObj<B>;
+  readonly morphism: SetMulti<A, B>;
+  readonly label?: string;
+}
+
+export interface DeterministicSetMultResult<A, B> {
+  readonly deterministic: boolean;
+  readonly holds: boolean;
+  readonly witness: DeterministicSetMultWitness<A, B>;
+  readonly base?: (a: A) => B;
+  readonly counterexample?: { readonly input: A; readonly fibre: ReadonlySet<B> };
+  readonly details: string;
+}
+
+export interface DeterministicSetMultOptions<A> {
+  readonly samples?: Iterable<A>;
+}
+
+export const isDeterministicSetMulti = <A, B>(
+  witness: DeterministicSetMultWitness<A, B>,
+  options: DeterministicSetMultOptions<A> = {},
+): DeterministicSetMultResult<A, B> => {
+  const { domain, morphism } = witness;
+  const samples = options.samples ?? domain.samples ?? [];
+  for (const sample of samples) {
+    const fibre = morphism(sample);
+    if (fibre.size !== 1) {
+      return {
+        deterministic: false,
+        holds: false,
+        witness,
+        counterexample: { input: sample, fibre },
+        details: `Fibre over ${domain.show(sample)} has size ${fibre.size}`,
+      };
+    }
+  }
+  const base = (input: A): B => {
+    const fibre = morphism(input);
+    if (fibre.size !== 1) {
+      throw new Error("SetMulti is not deterministic on the provided input");
+    }
+    const iterator = fibre.values().next();
+    if (iterator.done) throw new Error("Deterministic fibre unexpectedly empty");
+    return iterator.value;
+  };
+  return { deterministic: true, holds: true, witness, base, details: "All sampled fibres are singleton" };
+};
+
+export const deterministicToSetMulti = <A, B>(
+  domain: SetMultObj<A>,
+  codomain: SetMultObj<B>,
+  fn: (a: A) => B,
+): SetMulti<A, B> => (input) => singletonFibre(fn(input), codomain.eq, codomain.show);
+
+export const setMultiToDeterministic = <A, B>(
+  witness: DeterministicSetMultWitness<A, B>,
+  options: DeterministicSetMultOptions<A> = {},
+): ((a: A) => B) | undefined => {
+  const result = isDeterministicSetMulti(witness, options);
+  return result.deterministic ? result.base : undefined;
+};
+
+export const kernelToSetMulti = <A, B>(
+  codomain: Fin<B>,
+  kernel: Kernel<A, B>,
+): SetMulti<A, B> => (input) => {
+  const dist = kernel(input);
+  const support = normalizeFibre(distKeys(dist), codomain.eq, codomain.show ?? defaultShow);
+  if (support.size === 0) {
+    throw new Error("Kernel has empty support for SetMulti conversion");
+  }
+  return support;
+};
+
+const distKeys = <B>(dist: Map<B, unknown>): Iterable<B> => {
+  const keys: B[] = [];
+  dist.forEach((_, value) => keys.push(value));
+  return keys;
+};
+
+export const setMultiToKernel = <A, B>(
+  domain: Fin<A>,
+  codomain: Fin<B>,
+  witness: DeterministicSetMultWitness<A, B>,
+): Kernel<A, B> => {
+  const base = setMultiToDeterministic(witness, { samples: domain.elems });
+  if (!base) {
+    throw new Error("Cannot convert non-deterministic SetMulti to kernel");
+  }
+  return deterministic(base);
+};
+
+export interface SetMultIndexedFamily<J, X> {
+  readonly index: Iterable<J>;
+  readonly coordinate: (index: J) => SetMultObj<X>;
+  readonly countability?: CountabilityWitness<J>;
+}
+
+export type SetMultTuple<J, X> = ReadonlyMap<J, X>;
+
+export interface SetMultProduct<J, X> {
+  readonly index: Iterable<J>;
+  readonly coordinate: (index: J) => SetMultObj<X>;
+  readonly carrier: (assignment: (index: J) => X) => SetMultTuple<J, X>;
+  readonly project: (tuple: SetMultTuple<J, X>, finite: ReadonlyArray<J>) => SetMultTuple<J, X>;
+  readonly object: SetMultObj<SetMultTuple<J, X>>;
+  readonly sectionObj: (subset: ReadonlyArray<J>) => SetMultObj<SetMultTuple<J, X>>;
+  readonly countability?: CountabilityWitness<J>;
+}
+
+const describeIndex = (index: unknown): string => String(index);
+
+const showTuple = <J, X>(
+  family: Pick<SetMultIndexedFamily<J, X>, "coordinate">,
+  indices: Iterable<J>,
+) => (tuple: SetMultTuple<J, X>): string => {
+  const entries: Array<string> = [];
+  for (const index of indices) {
+    const coordinate = family.coordinate(index);
+    const value = tuple.get(index);
+    if (value === undefined) {
+      entries.push(`${describeIndex(index)}:⟂`);
+    } else {
+      entries.push(`${describeIndex(index)}:${coordinate.show(value)}`);
+    }
+  }
+  return `{${entries.join(", ")}}`;
+};
+
+const eqTuple = <J, X>(
+  family: Pick<SetMultIndexedFamily<J, X>, "coordinate">,
+  indices: Iterable<J>,
+) => (left: SetMultTuple<J, X>, right: SetMultTuple<J, X>): boolean => {
+  for (const index of indices) {
+    const coordinate = family.coordinate(index);
+    const leftValue = left.get(index);
+    const rightValue = right.get(index);
+    if (leftValue === undefined || rightValue === undefined) {
+      return false;
+    }
+    if (!coordinate.eq(leftValue, rightValue)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const tupleEntries = <J, X>(tuple: SetMultTuple<J, X>): Array<J> => Array.from(tuple.keys());
+
+export const createSetMultProductObj = <J, X>(
+  family: SetMultIndexedFamily<J, X>,
+  options: { readonly label?: string } = {},
+): SetMultObj<SetMultTuple<J, X>> =>
+  createSetMultObj({
+    eq: (left, right) => {
+      if (left.size !== right.size) return false;
+      for (const [index, value] of left) {
+        const coordinate = family.coordinate(index);
+        const other = right.get(index);
+        if (other === undefined || !coordinate.eq(value, other)) {
+          return false;
+        }
+      }
+      return true;
+    },
+    show: (tuple) => {
+      const entries = tupleEntries(tuple).map((index) => {
+        const coordinate = family.coordinate(index);
+        const value = tuple.get(index);
+        return `${describeIndex(index)}:${value === undefined ? "⟂" : coordinate.show(value)}`;
+      });
+      entries.sort();
+      return `{${entries.join(", ")}}`;
+    },
+    label: options.label,
+  });
+
+export const createSetMultSectionObj = <J, X>(
+  family: Pick<SetMultIndexedFamily<J, X>, "coordinate">,
+  subset: ReadonlyArray<J>,
+  options: { readonly label?: string } = {},
+): SetMultObj<SetMultTuple<J, X>> =>
+  createSetMultObj({
+    eq: eqTuple(family, subset),
+    show: showTuple(family, subset),
+    label: options.label,
+  });
+
+export const createSetMultInfObj = <J, X>(
+  family: SetMultIndexedFamily<J, X>,
+): SetMultProduct<J, X> => {
+  const project = (tuple: ReadonlyMap<J, X>, finite: ReadonlyArray<J>): ReadonlyMap<J, X> => {
+    const section = new Map<J, X>();
+    for (const index of finite) {
+      const value = tuple.get(index);
+      if (value === undefined) {
+        throw new Error(`Tuple missing coordinate ${String(index)}`);
+      }
+      section.set(index, value);
+    }
+    return section;
+  };
+
+  const carrier = (assignment: (index: J) => X): ReadonlyMap<J, X> => {
+    const tuple = new Map<J, X>();
+    for (const index of family.index) {
+      tuple.set(index, assignment(index));
+    }
+    return tuple;
+  };
+
+  const object = createSetMultProductObj(family);
+
+  const sectionObj = (subset: ReadonlyArray<J>) => createSetMultSectionObj(family, subset);
+
+  return {
+    index: family.index,
+    coordinate: family.coordinate,
+    carrier,
+    project,
+    object,
+    sectionObj,
+    countability: family.countability,
+  };
+};
+
+export const projectSetMult = <J, X>(
+  product: SetMultProduct<J, X>,
+  subset: ReadonlyArray<J>,
+): SetMulti<SetMultTuple<J, X>, SetMultTuple<J, X>> => {
+  const codomain = product.sectionObj(subset);
+  return (tuple) => {
+    const section = product.project(tuple, subset);
+    return singletonFibre(section, codomain.eq, codomain.show);
+  };
+};
+
+export const setMultSupport = <A, B>(
+  codomain: SetMultObj<B>,
+  morphism: SetMulti<A, B>,
+  inputs: Iterable<A>,
+): Map<A, ReadonlySet<B>> => {
+  const support = new Map<A, ReadonlySet<B>>();
+  for (const input of inputs) {
+    support.set(input, normalizeFibre(morphism(input), codomain.eq, codomain.show));
+  }
+  return support;
+};
+
+// 🔮 END_MATH

--- a/setmult-oracles.ts
+++ b/setmult-oracles.ts
@@ -1,0 +1,255 @@
+// 🔮 BEGIN_MATH: SetMultOracles
+// 📝 Brief: Executable checks for Set-based multivalued morphisms and their infinite products.
+// 🏗️ Domain: Category theory / Set-valued functors
+// 🔗 Integration: Complements Markov and semicartesian infrastructure with SetMult diagnostics.
+// 📋 Plan:
+//   1. Validate copy/discard semicartesian laws on sample points.
+//   2. Confirm infinite-product projections agree with Set cartesian products.
+//   3. Expose determinism checks that certify singleton fibres.
+
+import type { CountabilityWitness } from "./markov-infinite";
+import type {
+  DeterministicSetMultResult,
+  DeterministicSetMultWitness,
+  SetMultIndexedFamily,
+  SetMultObj,
+  SetMulti,
+} from "./setmult-category";
+import {
+  composeSetMulti,
+  copySetMulti,
+  createSetMultInfObj,
+  deterministicToSetMulti,
+  discardSetMulti,
+  idSetMulti,
+  isDeterministicSetMulti,
+  setMultUnit,
+  setMultUnitObj,
+  tensorSetMulti,
+  tensorSetMultObj,
+} from "./setmult-category";
+
+type Triple<T> = readonly [T, T, T];
+
+const equalSet = <T>(eq: (a: T, b: T) => boolean, left: ReadonlySet<T>, right: ReadonlySet<T>): boolean => {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    let found = false;
+    for (const candidate of right) {
+      if (eq(candidate, value)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) return false;
+  }
+  return true;
+};
+
+const flattenLeftTriple = <T>(value: readonly [readonly [T, T], T]): Triple<T> => [value[0][0], value[0][1], value[1]];
+const flattenRightTriple = <T>(value: readonly [T, readonly [T, T]]): Triple<T> => [value[0], value[1][0], value[1][1]];
+
+const tripleEq = <T>(eq: (a: T, b: T) => boolean) => (a: Triple<T>, b: Triple<T>): boolean =>
+  eq(a[0], b[0]) && eq(a[1], b[1]) && eq(a[2], b[2]);
+
+export interface SetMultComonoidFailure<T> {
+  readonly sample: T;
+  readonly law: "copy" | "discard" | "coassociativity" | "leftCounit" | "rightCounit";
+  readonly expected: string;
+  readonly actual: string;
+}
+
+export interface SetMultComonoidReport<T> {
+  readonly holds: boolean;
+  readonly details: string;
+  readonly failures: ReadonlyArray<SetMultComonoidFailure<T>>;
+}
+
+const describeSet = <T>(show: (value: T) => string, set: ReadonlySet<T>): string =>
+  `{${Array.from(set).map((value) => show(value)).join(", ")}}`;
+
+export function checkSetMultComonoid<T>(
+  object: SetMultObj<T>,
+  samples: ReadonlyArray<T>,
+): SetMultComonoidReport<T> {
+  const failures: Array<SetMultComonoidFailure<T>> = [];
+  const copy = copySetMulti(object);
+  const discard = discardSetMulti<T>();
+  const id = idSetMulti(object);
+
+  const pairObj = tensorSetMultObj(object, object);
+  const leftTensorObj = tensorSetMultObj(pairObj, object);
+  const rightTensorObj = tensorSetMultObj(object, pairObj);
+
+  const copyTensorId = tensorSetMulti(leftTensorObj, copy, id);
+  const idTensorCopy = tensorSetMulti(rightTensorObj, id, copy);
+
+  const leftAssociative = composeSetMulti(leftTensorObj, copy, copyTensorId);
+  const rightAssociative = composeSetMulti(rightTensorObj, copy, idTensorCopy);
+
+  const discardTensorId = tensorSetMulti(tensorSetMultObj(setMultUnitObj, object), discard, id);
+  const idTensorDiscard = tensorSetMulti(tensorSetMultObj(object, setMultUnitObj), id, discard);
+
+  const projectRight = deterministicToSetMulti(
+    tensorSetMultObj(setMultUnitObj, object),
+    object,
+    ([, value]) => value,
+  );
+  const projectLeft = deterministicToSetMulti(
+    tensorSetMultObj(object, setMultUnitObj),
+    object,
+    ([value]) => value,
+  );
+
+  const leftCounit = composeSetMulti(
+    object,
+    copy,
+    composeSetMulti(object, discardTensorId, projectRight),
+  );
+  const rightCounit = composeSetMulti(
+    object,
+    copy,
+    composeSetMulti(object, idTensorDiscard, projectLeft),
+  );
+
+  const tripleShow = (triple: Triple<T>): string =>
+    `(${object.show(triple[0])}, ${object.show(triple[1])}, ${object.show(triple[2])})`;
+
+  for (const sample of samples) {
+    const copyFibre = copy(sample);
+    if (!equalSet(pairObj.eq, copyFibre, new Set([[sample, sample] as const]))) {
+      failures.push({
+        sample,
+        law: "copy",
+        expected: `{{(${object.show(sample)}, ${object.show(sample)})}}`,
+        actual: describeSet(([x, y]) => `(${object.show(x)}, ${object.show(y)})`, copyFibre),
+      });
+    }
+
+    const discardFibre = discard(sample);
+    if (discardFibre.size !== 1 || !discardFibre.has(setMultUnit)) {
+      failures.push({
+        sample,
+        law: "discard",
+        expected: "{⋆}",
+        actual: describeSet(setMultUnitObj.show, discardFibre),
+      });
+    }
+
+    const leftTriples = new Set(Array.from(leftAssociative(sample), flattenLeftTriple));
+    const rightTriples = new Set(Array.from(rightAssociative(sample), flattenRightTriple));
+    if (!equalSet(tripleEq(object.eq), leftTriples, rightTriples)) {
+      failures.push({
+        sample,
+        law: "coassociativity",
+        expected: describeSet(tripleShow, rightTriples),
+        actual: describeSet(tripleShow, leftTriples),
+      });
+    }
+
+    const leftCounitFibre = leftCounit(sample);
+    const rightCounitFibre = rightCounit(sample);
+    const identityFibre = id(sample);
+
+    if (!equalSet(object.eq, leftCounitFibre, identityFibre)) {
+      failures.push({
+        sample,
+        law: "leftCounit",
+        expected: describeSet(object.show, identityFibre),
+        actual: describeSet(object.show, leftCounitFibre),
+      });
+    }
+
+    if (!equalSet(object.eq, rightCounitFibre, identityFibre)) {
+      failures.push({
+        sample,
+        law: "rightCounit",
+        expected: describeSet(object.show, identityFibre),
+        actual: describeSet(object.show, rightCounitFibre),
+      });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `Copy/discard satisfied semicartesian laws on ${samples.length} sample${samples.length === 1 ? "" : "s"}.`
+    : `${failures.length} semicartesian check${failures.length === 1 ? "" : "s"} failed.`;
+
+  return { holds, details, failures };
+}
+
+export interface SetMultProjectionFailure<J> {
+  readonly subset: ReadonlyArray<J>;
+  readonly reason: string;
+}
+
+export interface SetMultInfiniteProductReport<J, X> {
+  readonly holds: boolean;
+  readonly details: string;
+  readonly failures: ReadonlyArray<SetMultProjectionFailure<J>>;
+  readonly countability?: CountabilityWitness<J>;
+}
+
+export interface SetMultProjectionTest<J, X> {
+  readonly subset: ReadonlyArray<J>;
+  readonly expected?: ReadonlyMap<J, X>;
+}
+
+export function checkSetMultInfiniteProduct<J, X>(
+  family: SetMultIndexedFamily<J, X>,
+  assignment: (index: J) => X,
+  tests: ReadonlyArray<SetMultProjectionTest<J, X>>,
+): SetMultInfiniteProductReport<J, X> {
+  const product = createSetMultInfObj(family);
+  const tuple = product.carrier(assignment);
+  const failures: Array<SetMultProjectionFailure<J>> = [];
+
+  for (const test of tests) {
+    const projection = product.project(tuple, test.subset);
+    const expected = test.expected ?? new Map(test.subset.map((index) => [index, assignment(index)]));
+    let ok = projection.size === expected.size;
+    if (ok) {
+      for (const index of test.subset) {
+        if (!projection.has(index) || projection.get(index) !== expected.get(index)) {
+          ok = false;
+          break;
+        }
+      }
+    }
+    if (!ok) {
+      failures.push({
+        subset: test.subset,
+        reason: `Projection differed: expected ${JSON.stringify(Array.from(expected.entries()))} but received ${JSON.stringify(
+          Array.from(projection.entries()),
+        )}`,
+      });
+    }
+  }
+
+  const holds = failures.length === 0;
+  const details = holds
+    ? `All ${tests.length} projections matched the Set-theoretic product.`
+    : `${failures.length} projection${failures.length === 1 ? "" : "s"} failed.`;
+
+  return { holds, details, failures, countability: product.countability };
+}
+
+export interface SetMultDeterminismSummary<A, B> {
+  readonly holds: boolean;
+  readonly details: string;
+  readonly report: DeterministicSetMultResult<A, B>;
+}
+
+export function checkSetMultDeterministic<A, B>(
+  witness: DeterministicSetMultWitness<A, B>,
+  samples: Iterable<A>,
+): SetMultDeterminismSummary<A, B> {
+  const report = isDeterministicSetMulti(witness, { samples });
+  return {
+    holds: report.deterministic,
+    details: report.details,
+    report,
+  };
+}
+
+// 🔮 END_MATH

--- a/test/laws/law.CRingPlusCausalityCounterexample.spec.ts
+++ b/test/laws/law.CRingPlusCausalityCounterexample.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCRingPlusCausalityScenario,
+  checkCRingPlusCausalityCounterexample,
+  composeHom,
+  equalHom,
+  polynomialMonomial,
+  polynomialFormat,
+} from "../../cring-plus";
+
+import type { Polynomial } from "../../cring-plus";
+
+const formatPoly = (poly: Polynomial) => polynomialFormat(poly);
+
+describe("CRing_⊕ causality counterexample", () => {
+  it("counterexample oracle reports equality after observation and inequality before", () => {
+    const analysis = checkCRingPlusCausalityCounterexample();
+    expect(analysis.holds).toBe(true);
+    expect(analysis.equalAfterObservation).toBe(true);
+    expect(analysis.equalBeforeObservation).toBe(false);
+    expect(analysis.witness).toBeDefined();
+    expect(analysis.details).toContain("premise but violate");
+  });
+
+  it("morphisms preserve additive/unit structure", () => {
+    const analysis = checkCRingPlusCausalityCounterexample();
+    expect(analysis.homChecks.observe.holds).toBe(true);
+    expect(analysis.homChecks.future.holds).toBe(true);
+    expect(analysis.homChecks.pastCanonical.holds).toBe(true);
+    expect(analysis.homChecks.pastIdentity.holds).toBe(true);
+  });
+
+  it("witness highlights difference on the t monomial", () => {
+    const scenario = buildCRingPlusCausalityScenario();
+    const futureAfterCanonical = composeHom(scenario.future, scenario.pastCanonical);
+    const futureAfterIdentity = composeHom(scenario.future, scenario.pastIdentity);
+    const observedCanonical = composeHom(scenario.observe, futureAfterCanonical);
+    const observedIdentity = composeHom(scenario.observe, futureAfterIdentity);
+
+    const monomialT = polynomialMonomial(1);
+    const shiftedCanonical = futureAfterCanonical.map(monomialT);
+    const shiftedIdentity = futureAfterIdentity.map(monomialT);
+
+    expect(equalHom(observedCanonical, observedIdentity)).toBe(true);
+    expect(equalHom(futureAfterCanonical, futureAfterIdentity)).toBe(false);
+    expect(formatPoly(shiftedCanonical)).toBe("1");
+    expect(formatPoly(shiftedIdentity)).toBe("1 + 1·t");
+    expect(formatPoly(monomialT)).toBe("1·t");
+  });
+});

--- a/test/laws/law.CRingPlusInfiniteTensorColimit.spec.ts
+++ b/test/laws/law.CRingPlusInfiniteTensorColimit.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { IntegersObject } from "../../cring-plus";
+import {
+  addTensors,
+  checkColimitCoverage,
+  checkFilteredCompatibility,
+  defaultFilteredWitness,
+  elementaryTensor,
+  multiplyTensors,
+  negateTensor,
+  restrictTensor,
+  tensorSupport,
+  type TensorFamily,
+  type TensorElement,
+} from "../../cring-plus-filtered-tensor";
+
+const family: TensorFamily<string, bigint> = {
+  components: [
+    { index: "a", object: IntegersObject },
+    { index: "b", object: IntegersObject },
+    { index: "c", object: IntegersObject },
+  ],
+  eqIndex: (x, y) => x === y,
+  describeIndex: (index) => index,
+};
+
+const witness = defaultFilteredWitness(family);
+
+const tensorA = elementaryTensor(family, [{ index: "a", value: 2n }]);
+const tensorB = elementaryTensor(family, [{ index: "b", value: 3n }]);
+const tensorC = elementaryTensor(family, [{ index: "c", value: 5n }]);
+
+describe("CRing⊕ infinite tensor filtered colimit", () => {
+  it("normalizes addition and negation of formal tensors", () => {
+    const doubled = addTensors(family, tensorA, tensorA);
+    expect(doubled.terms).toHaveLength(1);
+    expect(doubled.terms[0].coefficient).toBe(2n);
+    expect(doubled.terms[0].entries).toHaveLength(1);
+    expect(doubled.terms[0].entries[0]?.value).toBe(2n);
+
+    const cancelled = addTensors(family, doubled, negateTensor(family, tensorA));
+    expect(cancelled.terms).toHaveLength(1);
+    expect(cancelled.terms[0]?.coefficient).toBe(1n);
+  });
+
+  it("multiplies elementary tensors by combining finite supports", () => {
+    const product = multiplyTensors(family, tensorA, tensorB);
+    expect(product.terms).toHaveLength(1);
+    const entries = product.terms[0]?.entries ?? [];
+    expect(entries).toHaveLength(2);
+    const keys = entries.map((entry) => entry.key).sort();
+    expect(keys).toEqual(["a", "b"]);
+  });
+
+  it("restricts tensors to finite subsets", () => {
+    const product = multiplyTensors(family, tensorA, tensorB);
+    const restricted = restrictTensor(family, product, ["a"]);
+    expect(restricted.terms).toHaveLength(1);
+    expect(restricted.terms[0]?.entries).toHaveLength(1);
+    expect(restricted.terms[0]?.entries[0]?.key).toBe("a");
+  });
+
+  it("verifies filtered-compatibility of inclusions", () => {
+    const compat = checkFilteredCompatibility(witness, [
+      { smaller: ["a"], larger: ["a", "b"], samples: [tensorA] },
+      { smaller: ["b"], larger: ["a", "b", "c"], samples: [tensorB] },
+    ]);
+    expect(compat.holds).toBe(true);
+    expect(compat.failures).toHaveLength(0);
+  });
+
+  it("recovers tensors from their finite supports", () => {
+    const samples: TensorElement<string, bigint>[] = [
+      multiplyTensors(family, tensorA, tensorB),
+      addTensors(family, tensorA, tensorC),
+    ];
+    const coverage = checkColimitCoverage(witness, samples);
+    expect(coverage.holds).toBe(true);
+    expect(coverage.failures).toHaveLength(0);
+  });
+
+  it("tracks tensor support sets", () => {
+    const sum = addTensors(family, tensorA, addTensors(family, tensorB, tensorC));
+    const support = tensorSupport(family, sum).sort();
+    expect(support).toEqual(["a", "b", "c"]);
+  });
+});

--- a/test/laws/law.CStarAlgebra.spec.ts
+++ b/test/laws/law.CStarAlgebra.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  ComplexCStarAlgebra,
+  checkCStarAxioms,
+  checkCStarHomomorphism,
+  checkCStarSpectralTheory,
+  complex,
+  checkComplexCStarAxioms,
+  checkComplexIdentityHomomorphism,
+  checkComplexSpectralTheory,
+  imaginaryPartCStar,
+  isNormal,
+  isSelfAdjoint,
+  realPartCStar,
+  type ComplexNumber,
+  type CStarAlgebra,
+  type CStarHomomorphism,
+} from "../../cstar-algebra";
+
+const samples: ReadonlyArray<ComplexNumber> = [
+  complex(0, 0),
+  complex(1, 0),
+  complex(0, 1),
+  complex(-2, 3),
+];
+
+const scalars: ReadonlyArray<ComplexNumber> = [
+  complex(1, 0),
+  complex(0, 1),
+  complex(2, -1),
+];
+
+describe("C*-algebra diagnostics", () => {
+  it("verifies the complex numbers satisfy the C*-axioms", () => {
+    const report = checkCStarAxioms(ComplexCStarAlgebra, samples, scalars);
+    expect(report.holds).toBe(true);
+    expect(report.failures).toHaveLength(0);
+  });
+
+  it("flags violations when the star operation is replaced by the identity", () => {
+    const degenerate: CStarAlgebra<ComplexNumber> = {
+      ...ComplexCStarAlgebra,
+      star: (z) => z,
+      positive: ComplexCStarAlgebra.positive,
+    };
+    const report = checkCStarAxioms(degenerate, samples, scalars);
+    expect(report.holds).toBe(false);
+    expect(report.failures.some((failure) => failure.axiom === "positivity")).toBe(true);
+  });
+
+  it("accepts the identity *-homomorphism on complex numbers", () => {
+    const homReport = checkCStarHomomorphism(
+      ComplexCStarAlgebra,
+      ComplexCStarAlgebra,
+      { map: (value) => value, label: "id" },
+      samples,
+      scalars,
+    );
+    expect(homReport.holds).toBe(true);
+    expect(homReport.failures).toHaveLength(0);
+  });
+
+  it("detects a non *-preserving morphism", () => {
+    const forgetImaginary: CStarHomomorphism<ComplexNumber, ComplexNumber> = {
+      map: (value) => complex(value.re, 0),
+      label: "forgetImaginary",
+    };
+    const report = checkCStarHomomorphism(
+      ComplexCStarAlgebra,
+      ComplexCStarAlgebra,
+      forgetImaginary,
+      samples,
+      scalars,
+    );
+    expect(report.holds).toBe(false);
+    expect(report.failures.some((failure) => failure.law === "scalar")).toBe(true);
+  });
+
+  it("analyzes spectral decomposition and self-adjoint parts", () => {
+    const z = complex(2, -3);
+    const real = realPartCStar(ComplexCStarAlgebra, z);
+    const imag = imaginaryPartCStar(ComplexCStarAlgebra, z);
+    expect(isSelfAdjoint(ComplexCStarAlgebra, real)).toBe(true);
+    expect(isSelfAdjoint(ComplexCStarAlgebra, imag)).toBe(true);
+    expect(isSelfAdjoint(ComplexCStarAlgebra, z)).toBe(false);
+    expect(isNormal(ComplexCStarAlgebra, z)).toBe(true);
+    const recomposed = ComplexCStarAlgebra.add(
+      real,
+      ComplexCStarAlgebra.scalar(complex(0, 1), imag),
+    );
+    expect(ComplexCStarAlgebra.equal(recomposed, z, 1e-9)).toBe(true);
+
+    const spectral = checkCStarSpectralTheory(ComplexCStarAlgebra, samples);
+    expect(spectral.holds).toBe(true);
+    spectral.entries.forEach((entry) => {
+      expect(entry.realSelfAdjoint).toBe(true);
+      expect(entry.imaginarySelfAdjoint).toBe(true);
+      expect(entry.decompositionValid).toBe(true);
+    });
+  });
+
+  it("exposes the canned registry helpers", () => {
+    const axioms = checkComplexCStarAxioms();
+    const hom = checkComplexIdentityHomomorphism();
+    const spectral = checkComplexSpectralTheory();
+    expect(axioms.holds).toBe(true);
+    expect(hom.holds).toBe(true);
+    expect(spectral.holds).toBe(true);
+  });
+});

--- a/test/laws/law.MarkovAlmostSureEquality.spec.ts
+++ b/test/laws/law.MarkovAlmostSureEquality.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { mkFin, FinMarkov } from "../../markov-category";
+import {
+  buildMarkovAlmostSureWitness,
+  checkAlmostSureEquality,
+} from "../../markov-almost-sure";
+
+describe("p-almost-sure equality", () => {
+  it("treats morphisms that agree on the support of p as almost surely equal", () => {
+    type A = "a0" | "a1";
+    type X = "x0" | "x1";
+    type Y = 0 | 1;
+
+    const AFin = mkFin<A>(["a0", "a1"], (a, b) => a === b);
+    const XFin = mkFin<X>(["x0", "x1"], (a, b) => a === b);
+    const YFin = mkFin<Y>([0, 1], (a, b) => a === b);
+
+    const prior = new FinMarkov(AFin, XFin, () => new Map<X, number>([["x0", 1]]));
+
+    const left = new FinMarkov(XFin, YFin, (x: X) =>
+      x === "x0"
+        ? new Map<Y, number>([[0, 1]])
+        : new Map<Y, number>([
+            [0, 0.2],
+            [1, 0.8],
+          ]),
+    );
+
+    const right = new FinMarkov(XFin, YFin, (x: X) =>
+      x === "x0"
+        ? new Map<Y, number>([[0, 1]])
+        : new Map<Y, number>([
+            [0, 0.7],
+            [1, 0.3],
+          ]),
+    );
+
+    const witness = buildMarkovAlmostSureWitness(prior, left, right, { label: "example" });
+    const report = checkAlmostSureEquality(witness);
+
+    expect(report.holds).toBe(true);
+    expect(report.failures).toHaveLength(0);
+    expect(report.support).toHaveLength(1);
+    expect(report.support[0].value).toBe("x0");
+    expect(report.support[0].totalMass).toBeCloseTo(2, 10);
+    expect(report.support[0].contributions).toHaveLength(2);
+    expect(report.support[0].contributions.map((c) => c.input)).toEqual(["a0", "a1"]);
+    expect(report.support[0].contributions.map((c) => c.weight)).toEqual([1, 1]);
+    expect(report.composite).toBeDefined();
+    expect(report.equalComposite).toBe(true);
+  });
+
+  it("detects almost-sure failures on supported points", () => {
+    type A = "a0" | "a1";
+    type X = "x0" | "x1";
+    type Y = 0 | 1;
+
+    const AFin = mkFin<A>(["a0", "a1"], (a, b) => a === b);
+    const XFin = mkFin<X>(["x0", "x1"], (a, b) => a === b);
+    const YFin = mkFin<Y>([0, 1], (a, b) => a === b);
+
+    const prior = new FinMarkov(AFin, XFin, (a: A) =>
+      a === "a0"
+        ? new Map<X, number>([
+            ["x0", 0.2],
+            ["x1", 0.8],
+          ])
+        : new Map<X, number>([["x1", 1]])
+    );
+
+    const left = new FinMarkov(XFin, YFin, (x: X) =>
+      x === "x1"
+        ? new Map<Y, number>([
+            [0, 0.2],
+            [1, 0.8],
+          ])
+        : new Map<Y, number>([[0, 1]]),
+    );
+
+    const right = new FinMarkov(XFin, YFin, (x: X) =>
+      x === "x1"
+        ? new Map<Y, number>([
+            [0, 0.7],
+            [1, 0.3],
+          ])
+        : new Map<Y, number>([[0, 1]]),
+    );
+
+    const witness = buildMarkovAlmostSureWitness(prior, left, right, { label: "failure" });
+    const report = checkAlmostSureEquality(witness);
+
+    expect(report.holds).toBe(false);
+    expect(report.equalComposite).toBe(false);
+    expect(report.support).toHaveLength(2);
+    expect(report.failures).toHaveLength(1);
+    const failure = report.failures[0];
+    expect(failure.supportPoint).toBe("x1");
+    expect(new Set(failure.sources)).toEqual(new Set(["a0", "a1"]));
+    expect(failure.differences).toHaveLength(2);
+    expect(failure.differences.map((entry) => entry.value).sort()).toEqual([0, 1]);
+  });
+
+  it("honours custom tolerances when comparing distributions", () => {
+    type A = "a";
+    type X = "x";
+    type Y = 0 | 1;
+
+    const AFin = mkFin<A>(["a"], (a, b) => a === b);
+    const XFin = mkFin<X>(["x"], (a, b) => a === b);
+    const YFin = mkFin<Y>([0, 1], (a, b) => a === b);
+
+    const prior = new FinMarkov(AFin, XFin, () => new Map<X, number>([["x", 1]]));
+    const left = new FinMarkov(XFin, YFin, () => new Map<Y, number>([[0, 0.5], [1, 0.5]]));
+    const right = new FinMarkov(XFin, YFin, () => new Map<Y, number>([[0, 0.5000005], [1, 0.4999995]]));
+
+    const witness = buildMarkovAlmostSureWitness(prior, left, right);
+    const tightReport = checkAlmostSureEquality(witness);
+    const looseReport = checkAlmostSureEquality(witness, { tolerance: 1e-6 });
+
+    expect(tightReport.holds).toBe(false);
+    expect(looseReport.holds).toBe(true);
+  });
+});

--- a/test/laws/law.MarkovConditionalIndependence.spec.ts
+++ b/test/laws/law.MarkovConditionalIndependence.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { mkFin, detK, tensorObj, FinMarkov } from "../../markov-category";
+import { buildMarkovComonoidWitness } from "../../markov-comonoid-structure";
+import {
+  buildMarkovConditionalWitness,
+  checkConditionalIndependence,
+  conditionalMarginals,
+  factorizeConditional,
+} from "../../markov-conditional-independence";
+import { buildMarkovDeterministicWitness, checkDeterminismLemma } from "../../markov-deterministic-structure";
+
+const mkBit = () => mkFin<number>([0, 1], (a, b) => a === b, (x) => x.toString());
+type SampleState = "a0" | "a1";
+
+describe("conditional independence", () => {
+  it("confirms factorization for conditionally independent kernels", () => {
+    type A = "a0" | "a1";
+    const AFin = mkFin<A>(["a0", "a1"], (a, b) => a === b);
+    const Bit1 = mkBit();
+    const Bit2 = mkBit();
+
+    const domain = buildMarkovComonoidWitness(AFin, { label: "A" });
+    const out1 = buildMarkovComonoidWitness(Bit1, { label: "X₁" });
+    const out2 = buildMarkovComonoidWitness(Bit2, { label: "X₂" });
+
+    const first = detK(AFin, Bit1, (a) => (a === "a0" ? 0 : 1));
+    const second = new FinMarkov(
+      AFin,
+      Bit2,
+      (a: A) =>
+        a === "a0"
+          ? new Map<number, number>([
+              [0, 0.7],
+              [1, 0.3],
+            ])
+          : new Map<number, number>([
+              [0, 0.2],
+              [1, 0.8],
+            ]),
+    );
+
+    const product = tensorObj(Bit1, Bit2);
+    const arrow = new FinMarkov(AFin, product, (a: A) => {
+      const dist = new Map<readonly [number, number], number>();
+      const d1 = first.k(a);
+      const d2 = second.k(a);
+      for (const [x, px] of d1) {
+        for (const [y, py] of d2) {
+          const weight = px * py;
+          if (weight === 0) continue;
+          const key = [x, y] as const;
+          dist.set(key, (dist.get(key) ?? 0) + weight);
+        }
+      }
+      return dist;
+    });
+
+    const witness = buildMarkovConditionalWitness(domain, [out1, out2], arrow, { label: "p" });
+    const components = conditionalMarginals(witness);
+    expect(components).toHaveLength(2);
+    expect(components[0].Y).toBe(Bit1);
+    expect(components[1].Y).toBe(Bit2);
+
+    const factorized = factorizeConditional(witness);
+    const report = checkConditionalIndependence(witness, { permutations: [[1, 0]] });
+    expect(report.holds).toBe(true);
+    expect(report.equality).toBe(true);
+    expect(report.failures).toHaveLength(0);
+    expect(report.permutations).toHaveLength(1);
+    expect(report.permutations[0].holds).toBe(true);
+    expect(report.factorized.matrix()).toEqual(factorized.matrix());
+  });
+
+  it("detects correlated outputs that violate conditional independence", () => {
+    type A = "a0" | "a1";
+    const AFin = mkFin<A>(["a0", "a1"], (a, b) => a === b);
+    const Bit1 = mkBit();
+    const Bit2 = mkBit();
+
+    const domain = buildMarkovComonoidWitness(AFin, { label: "A" });
+    const out1 = buildMarkovComonoidWitness(Bit1, { label: "X₁" });
+    const out2 = buildMarkovComonoidWitness(Bit2, { label: "X₂" });
+
+    const correlated = new FinMarkov(
+      AFin,
+      tensorObj(Bit1, Bit2),
+      () =>
+        new Map<readonly [number, number], number>([
+          [[0, 0] as const, 0.5],
+          [[1, 1] as const, 0.5],
+        ]),
+    );
+
+    const witness = buildMarkovConditionalWitness(domain, [out1, out2], correlated, { label: "correlated" });
+    const report = checkConditionalIndependence(witness, { permutations: [[1, 0]] });
+
+    expect(report.holds).toBe(false);
+    expect(report.equality).toBe(false);
+    expect(report.failures.some((failure) => failure.law === "factorization")).toBe(true);
+    expect(report.permutations[0].holds).toBe(false);
+  });
+
+  it("records permutation validation errors", () => {
+    type A = "a";
+    const AFin = mkFin<A>(["a"], (a, b) => a === b);
+    const Bit = mkBit();
+    const domain = buildMarkovComonoidWitness(AFin, { label: "A" });
+    const out1 = buildMarkovComonoidWitness(Bit, { label: "X₁" });
+
+    const arrow = new FinMarkov(AFin, Bit, () => new Map([[0, 1]]));
+    const witness = buildMarkovConditionalWitness(domain, [out1], arrow, { label: "trivial" });
+    const report = checkConditionalIndependence(witness, { permutations: [[0, 1]] });
+
+    expect(report.holds).toBe(false);
+    expect(report.failures.some((failure) => failure.law === "permutation")).toBe(true);
+    expect(report.permutations[0].holds).toBe(false);
+  });
+});
+
+describe("determinism lemma", () => {
+  const buildDomain = () => {
+    const AFin = mkFin<SampleState>(["a0", "a1"], (a, b) => a === b);
+    const BitX = mkBit();
+    const BitT = mkBit();
+    const domain = buildMarkovComonoidWitness(AFin, { label: "A" });
+    const xWitness = buildMarkovComonoidWitness(BitX, { label: "X" });
+    const tWitness = buildMarkovComonoidWitness(BitT, { label: "T" });
+
+    const p = new FinMarkov(
+      AFin,
+      BitX,
+      (a: SampleState) =>
+        a === "a0"
+          ? new Map<number, number>([
+              [0, 0.6],
+              [1, 0.4],
+            ])
+          : new Map<number, number>([
+              [0, 0.3],
+              [1, 0.7],
+            ]),
+    );
+
+    const product = tensorObj(BitX, BitT);
+    const buildJoint = (statistic: FinMarkov<number, number>) =>
+      new FinMarkov(AFin, product, (a: SampleState) => {
+        const dist = new Map<readonly [number, number], number>();
+        for (const [x, px] of p.k(a)) {
+          if (px === 0) continue;
+          for (const [tValue, pt] of statistic.k(x)) {
+            const weight = px * pt;
+            if (weight === 0) continue;
+            const key = [x, tValue] as const;
+            dist.set(key, (dist.get(key) ?? 0) + weight);
+          }
+        }
+        return dist;
+      });
+
+    return { A: AFin, X: BitX, T: BitT, product, domain, xWitness, tWitness, p, buildJoint };
+  };
+
+  it("certifies deterministic composites when conditional independence holds", () => {
+    const { X, T, domain, xWitness, tWitness, p, buildJoint } = buildDomain();
+
+    const constantStatistic = detK(X, T, () => 0);
+    const deterministicWitness = buildMarkovDeterministicWitness(xWitness, tWitness, constantStatistic, {
+      label: "constant statistic",
+    });
+
+    const composite = p.then(constantStatistic);
+    const joint = buildJoint(constantStatistic);
+
+    const conditional = buildMarkovConditionalWitness(domain, [xWitness, tWitness], joint, {
+      label: "joint with constant statistic",
+    });
+
+    const report = checkDeterminismLemma({
+      conditional,
+      p,
+      deterministic: deterministicWitness,
+      label: "determinism lemma",
+    });
+
+    expect(report.holds).toBe(true);
+    expect(report.failures).toHaveLength(0);
+    expect(report.composite.deterministic).toBe(true);
+    expect(report.marginals.x.matrix()).toEqual(p.matrix());
+    expect(report.marginals.t.matrix()).toEqual(composite.matrix());
+  });
+
+  it("reports conditional-independence failures when correlation remains", () => {
+    const { X, T, domain, xWitness, tWitness, p, buildJoint } = buildDomain();
+
+    const identityStatistic = detK(X, T, (x: number) => x);
+    const deterministicWitness = buildMarkovDeterministicWitness(xWitness, tWitness, identityStatistic, {
+      label: "identity statistic",
+    });
+
+    const composite = p.then(identityStatistic);
+    const joint = buildJoint(identityStatistic);
+    const conditional = buildMarkovConditionalWitness(domain, [xWitness, tWitness], joint, {
+      label: "correlated joint",
+    });
+
+    const report = checkDeterminismLemma({
+      conditional,
+      p,
+      deterministic: deterministicWitness,
+      label: "correlated determinism lemma",
+    });
+
+    expect(report.holds).toBe(false);
+    expect(report.failures.some((failure) => failure.law === "conditionalIndependence")).toBe(true);
+    expect(report.composite.deterministic).toBe(false);
+    expect(report.marginals.t.matrix()).toEqual(composite.matrix());
+  });
+});

--- a/test/laws/law.MarkovInfinite.spec.ts
+++ b/test/laws/law.MarkovInfinite.spec.ts
@@ -1,0 +1,1261 @@
+import { describe, it, expect } from "vitest";
+import { Prob } from "../../semiring-utils";
+import { bind, dirac } from "../../dist";
+import {
+  independentIndexedProduct,
+  independentInfObj,
+  independentDoubleIndexedProduct,
+  createInfObj,
+  restrictProjectiveFamily,
+  restrictInfObj,
+  flattenNestedCylinder,
+  equalDist,
+  pushforwardCylinderArray,
+  checkKolmogorovConsistency,
+  deterministicBooleanValue,
+  tensorKolmogorovProducts,
+  asDeterministicKernel,
+  buildDeterministicKolmogorovProductWitness,
+  kolmogorovExtensionMeasure,
+  type MeasurabilityWitness,
+  type CountabilityWitness,
+  type CylinderSection,
+  type FiniteSubset,
+  type DoubleIndex,
+  type TensorIndex,
+  type TensorCarrier,
+} from "../../markov-infinite";
+import {
+  checkTailEventInvariance,
+  checkTailSigmaIndependence,
+  kolmogorovZeroOneWitness,
+  hewittSavageZeroOneWitness,
+  checkKolmogorovZeroOneLaw,
+  checkHewittSavageZeroOneLaw,
+  checkFiniteProductReduction,
+  checkCopyDiscardCompatibility,
+  checkKolmogorovProduct,
+  checkKolmogorovExtensionUniversalProperty,
+  checkDeterministicProductUniversalProperty,
+  analyzeFinStochInfiniteTensor,
+} from "../../markov-infinite-oracles";
+import type { Dist } from "../../dist";
+import type { ProjectiveLimitSection } from "../../markov-infinite";
+import { mkFin, detK, fromMatrix, tensorObj, pair, FinMarkov } from "../../markov-category";
+import { buildMarkovComonoidWitness } from "../../markov-comonoid-structure";
+import { buildMarkovDeterministicWitness } from "../../markov-deterministic-structure";
+import { buildMarkovConditionalWitness } from "../../markov-conditional-independence";
+
+const bernoulli = (p: number): Dist<number, number> => ({
+  R: Prob,
+  w: new Map<number, number>([
+    [1, p],
+    [0, 1 - p],
+  ]),
+});
+
+const makeMeasure = <T>(pairs: Array<[T, number]>): Dist<number, T> => ({ R: Prob, w: new Map(pairs) });
+
+const discreteWitness = (indices: Iterable<number>): MeasurabilityWitness<number> => {
+  const enumerated = Array.from(indices);
+  return {
+    kind: "standardBorel",
+    coordinates: enumerated.map((index) => ({
+      index,
+      sigmaAlgebra: "discrete",
+      standardBorel: true,
+    })),
+    reason: "Finite discrete spaces carry the discrete Borel sigma-algebra.",
+  };
+};
+
+const buildZeroOneFixtures = () => {
+  const indices = [0, 1, 2];
+  const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+    measurability: discreteWitness(indices),
+  });
+  const productWitness = obj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(obj);
+
+  const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+  const constantOne: ProjectiveLimitSection<number, number> = () => 1;
+
+  const sectionEquals = (
+    left: ProjectiveLimitSection<number, number>,
+    right: ProjectiveLimitSection<number, number>,
+  ): boolean => indices.every((index) => left(index) === right(index));
+
+  const carrierFin = mkFin<ProjectiveLimitSection<number, number>>(
+    [constantZero, constantOne],
+    sectionEquals,
+  );
+  const carrierWitness = buildMarkovComonoidWitness(carrierFin, { label: "Kolmogorov sections" });
+
+  const domainFin = mkFin<"zero" | "one">(["zero", "one"], (a, b) => a === b);
+  const domainWitness = buildMarkovComonoidWitness(domainFin, { label: "support" });
+
+  const boolFin = mkFin([0, 1], (a, b) => a === b);
+  const boolWitness = buildMarkovComonoidWitness(boolFin, { label: "boolean" });
+
+  const toSection = (state: "zero" | "one") => (state === "zero" ? constantZero : constantOne);
+  const p = detK(domainFin, carrierFin, toSection);
+
+  const fixtures = {
+    indices,
+    obj,
+    productWitness,
+    constantZero,
+    constantOne,
+    domainFin,
+    carrierFin,
+    boolFin,
+    domainWitness,
+    carrierWitness,
+    boolWitness,
+    p,
+  };
+  return fixtures;
+};
+
+describe("Markov infinite products", () => {
+  it("constructs projective families with Kolmogorov consistency", () => {
+    const indices = Array.from({ length: 4 }, (_, i) => i);
+    const explicitCountability: CountabilityWitness<number> = {
+      kind: "finite",
+      enumerate: () => indices,
+      sample: indices,
+      size: indices.length,
+      reason: "Explicit enumeration of a finite index set",
+    };
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      countability: explicitCountability,
+    });
+    const result = checkKolmogorovConsistency(family, [
+      { finite: [0], larger: [0, 1] },
+      { finite: [1, 2], larger: [0, 1, 2] },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(result.failures.length).toBe(0);
+    expect(result.countable).toBe(true);
+    expect(result.witness?.kind).toBeDefined();
+    expect(result.witness).toBe(explicitCountability);
+    expect(result.measurable).toBe(true);
+    expect(result.standardBorel).toBe(true);
+    expect(result.measurability?.kind).toBe("standardBorel");
+  });
+
+  it("falls back to inferred countability metadata when no witness is provided", () => {
+    const indices = Array.from({ length: 3 }, (_, i) => i);
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5));
+    expect(family.countability.kind).toBe("finite");
+    expect(family.countability.reason).toContain("Iterable terminated");
+    const obj = createInfObj(family);
+    expect(obj.family.countability).toBe(family.countability);
+  });
+
+  it("rejects malformed countability witnesses", () => {
+    const indices = [0, 1, 2];
+    const duplicateEnumeration = [0, 1, 1];
+    const badWitness: CountabilityWitness<number> = {
+      kind: "finite",
+      enumerate: () => duplicateEnumeration,
+      sample: indices,
+      reason: "Deliberately repeats elements",
+    };
+
+    expect(() =>
+      independentIndexedProduct(Prob, indices, () => bernoulli(0.5), { countability: badWitness })
+    ).toThrow(/repeats element/);
+  });
+
+  it("recovers finite tensor marginals when the index is finite", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+
+    const makeSection = (assignment: ReadonlyMap<number, number>) =>
+      ((index: number) => assignment.get(index) ?? 0) as ProjectiveLimitSection<number, number>;
+
+    const assignments = [
+      new Map<number, number>([]),
+      new Map<number, number>([[0, 1]]),
+      new Map<number, number>([[1, 1]]),
+      new Map<number, number>([[0, 1], [1, 1]]),
+    ];
+
+    const measure = makeMeasure(assignments.map((assignment) => [makeSection(assignment), 0.25]));
+
+    const reduction = checkFiniteProductReduction(obj, measure, indices);
+    expect(reduction.ok).toBe(true);
+    expect(reduction.expected.w.size).toBe(reduction.actual.w.size);
+    expect(obj.family.measurability?.kind).toBe("standardBorel");
+  });
+
+  it("extends consistent finite families into global measures", () => {
+    const indices = [0, 1, 2];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+
+    const result = checkKolmogorovExtensionUniversalProperty(obj, [[0], [0, 1]]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.countable).toBe(true);
+      expect(result.witness?.kind).toBeDefined();
+      expect(result.baseSubset).toEqual([0, 1]);
+      result.reductions.forEach((reduction) => expect(reduction.ok).toBe(true));
+      expect(result.measurable).toBe(true);
+      expect(result.standardBorel).toBe(true);
+    }
+  });
+
+  it("reports when extension data is missing", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5));
+    const familyWithoutExtend = { ...family, extend: undefined };
+    const obj = createInfObj(familyWithoutExtend);
+    const result = checkKolmogorovExtensionUniversalProperty(obj, [[0]]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("extension builder");
+      expect(result.countable).toBe(true);
+      expect(result.witness?.kind).toBeDefined();
+      expect(result.measurable).toBe(false);
+      expect(result.standardBorel).toBe(false);
+      expect(result.measurability).toBeUndefined();
+    }
+  });
+
+  it("aligns projections with copy/discard composition", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+
+    const sections: ProjectiveLimitSection<number, number>[] = [
+      (i) => (i === 0 ? 0 : 1),
+      (i) => (i === 1 ? 0 : 1),
+    ];
+
+    const compatibility = checkCopyDiscardCompatibility(obj, [[0], [1], indices], sections);
+    expect(compatibility.ok).toBe(true);
+    expect(compatibility.failures).toHaveLength(0);
+    expect(compatibility.countable).toBe(true);
+    expect(compatibility.witness?.kind).toBeDefined();
+    expect(compatibility.measurable).toBe(true);
+    expect(compatibility.standardBorel).toBe(true);
+  });
+
+  it("certifies Kolmogorov products via deterministic finite projections", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+
+    const samples: ProjectiveLimitSection<number, number>[] = [
+      (i) => (i === 0 ? 0 : 1),
+      (i) => (i === 0 ? 1 : 0),
+    ];
+
+    const result = checkKolmogorovProduct(obj, [[0], [1], indices], samples);
+    expect(result.ok).toBe(true);
+    expect(result.deterministic).toBe(true);
+    expect(result.copyDiscard.ok).toBe(true);
+    expect(result.determinismFailures).toHaveLength(0);
+    expect(result.countable).toBe(true);
+    expect(result.standardBorel).toBe(true);
+  });
+
+  it("detects non-deterministic marginals during Kolmogorov checks", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const base = createInfObj(family);
+
+    const projectKernel = (subset: ReadonlyArray<number>) => {
+      const baseKernel = base.projectKernel(subset);
+      return (section: ProjectiveLimitSection<number, number>) => {
+        const deterministic = baseKernel(section);
+        if (subset.length === 0) {
+          return deterministic;
+        }
+        const entries = Array.from(deterministic.w.entries());
+        if (entries.length === 0) {
+          return deterministic;
+        }
+        const [originalSection] = entries[0];
+        const primary = new Map(originalSection) as CylinderSection<number, number>;
+        const toggled = new Map(primary) as CylinderSection<number, number>;
+        const toggleIndex = subset[0];
+        const current = primary.get(toggleIndex) ?? 0;
+        toggled.set(toggleIndex, current === 0 ? 1 : 0);
+        const dist: Dist<number, CylinderSection<number, number>> = { R: Prob, w: new Map() };
+        dist.w.set(primary, 0.5);
+        dist.w.set(toggled, 0.5);
+        return dist;
+      };
+    };
+
+    const nondeterministic: typeof base = {
+      family: base.family,
+      copy: base.copy,
+      discard: base.discard,
+      projectKernel,
+      projectArray: (subset) => (carrier) => pushforwardCylinderArray(subset, projectKernel(subset)(carrier)),
+      liftKernel: (subset, kernel) => (carrier) => bind(projectKernel(subset)(carrier), kernel),
+      deterministicProjection: base.deterministicProjection,
+    };
+
+    const samples: ProjectiveLimitSection<number, number>[] = [
+      (i) => (i === 0 ? 0 : 1),
+      (i) => (i === 1 ? 0 : 1),
+    ];
+
+    const result = checkKolmogorovProduct(nondeterministic, [[0], [1], indices], samples);
+    expect(result.ok).toBe(false);
+    expect(result.deterministic).toBe(false);
+    expect(result.copyDiscard.ok).toBe(true);
+    expect(result.determinismFailures.length).toBeGreaterThan(0);
+  });
+
+  it("enforces singleton determinism automatically when positivity metadata is present", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const obj = createInfObj(family);
+
+    const samples: ProjectiveLimitSection<number, number>[] = [
+      (i) => (i === 0 ? 0 : 1),
+      (i) => (i === 1 ? 0 : 1),
+    ];
+
+    const result = checkKolmogorovProduct(obj, [indices], samples);
+    expect(result.ok).toBe(true);
+    expect(result.deterministic).toBe(true);
+    expect(result.determinismFailures).toHaveLength(0);
+  });
+
+  it("reports singleton failures via positivity-aware Kolmogorov checks", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const base = createInfObj(family);
+
+    const projectKernel = (subset: ReadonlyArray<number>) => {
+      const baseKernel = base.projectKernel(subset);
+      return (section: ProjectiveLimitSection<number, number>) => {
+        const deterministic = baseKernel(section);
+        if (subset.length === 0) {
+          return deterministic;
+        }
+        const entries = Array.from(deterministic.w.entries());
+        if (entries.length === 0) {
+          return deterministic;
+        }
+        const [originalSection] = entries[0];
+        const primary = new Map(originalSection) as CylinderSection<number, number>;
+        const toggled = new Map(primary) as CylinderSection<number, number>;
+        const toggleIndex = subset[0];
+        const current = primary.get(toggleIndex) ?? 0;
+        toggled.set(toggleIndex, current === 0 ? 1 : 0);
+        const dist: Dist<number, CylinderSection<number, number>> = { R: Prob, w: new Map() };
+        dist.w.set(primary, 0.5);
+        dist.w.set(toggled, 0.5);
+        return dist;
+      };
+    };
+
+    const nondeterministic: typeof base = {
+      family: base.family,
+      copy: base.copy,
+      discard: base.discard,
+      projectKernel,
+      projectArray: (subset) => (carrier) => pushforwardCylinderArray(subset, projectKernel(subset)(carrier)),
+      liftKernel: (subset, kernel) => (carrier) => bind(projectKernel(subset)(carrier), kernel),
+      positivity: base.positivity,
+      deterministicProjection: base.deterministicProjection,
+    };
+
+    const samples: ProjectiveLimitSection<number, number>[] = [
+      (i) => (i === 0 ? 0 : 1),
+      (i) => (i === 1 ? 0 : 1),
+    ];
+
+    const result = checkKolmogorovProduct(nondeterministic, [indices], samples);
+    expect(result.ok).toBe(false);
+    expect(result.deterministic).toBe(false);
+    expect(result.determinismFailures.some((failure) => failure.subset.length === 1)).toBe(true);
+  });
+
+  it("provides copy/discard and kernel lifting", () => {
+    const indices = Array.from({ length: 3 }, (_, i) => i);
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+    const delta = dirac(Prob);
+
+    const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+    const copy = obj.copy(constantZero);
+    expect(copy.w.size).toBe(1);
+    const [[pair, weight]] = Array.from(copy.w.entries());
+    expect(weight).toBeCloseTo(1);
+    expect(pair[0](0)).toBe(0);
+    expect(pair[1](1)).toBe(0);
+
+    const discarded = obj.discard(constantZero);
+    expect(discarded.w.size).toBe(1);
+    expect(Array.from(discarded.w.values())[0]).toBeCloseTo(1);
+
+    const projection = obj.projectKernel([0, 1])(constantZero);
+    const [[section, p]] = Array.from(projection.w.entries());
+    expect(p).toBeCloseTo(1);
+    expect(section.get(0)).toBe(0);
+    expect(section.get(1)).toBe(0);
+
+    const parityKernel = (s: ReadonlyMap<number, number>) =>
+      delta(((s.get(0) ?? 0) + (s.get(1) ?? 0)) % 2 === 0);
+    const lifted = obj.liftKernel([0, 1], parityKernel)(constantZero);
+    expect(deterministicBooleanValue(Prob, lifted)).toBe(true);
+  });
+
+  it("exposes deterministic projections and assembles deterministic mediators", () => {
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const obj = createInfObj(family);
+    const sample: ProjectiveLimitSection<number, number> = (index) => (index === 0 ? 1 : 0);
+
+    const singleton = obj.deterministicProjection(0);
+    expect(singleton(sample)).toBe(1);
+
+    const delta = asDeterministicKernel(Prob, singleton)(sample);
+    const [[value, weight]] = Array.from(delta.w.entries());
+    expect(weight).toBeCloseTo(1);
+    expect(value).toBe(1);
+
+    const witness = buildDeterministicKolmogorovProductWitness(obj);
+    const cached = witness.projection(1);
+    expect(cached.base(sample)).toBe(0);
+    const [[componentValue, componentWeight]] = Array.from(cached.kernel(sample).w.entries());
+    expect(componentWeight).toBeCloseTo(1);
+    expect(componentValue).toBe(0);
+
+    const mediator = witness.factor<number>([
+      { index: 0, base: (input) => input },
+      { index: 1, base: (input) => (input === 0 ? 1 : 0) },
+    ]);
+
+    expect(mediator.ok).toBe(true);
+    if (!mediator.ok || !mediator.base || !mediator.kernel) {
+      throw new Error("Expected deterministic mediator");
+    }
+
+    const mediatorBase = mediator.base;
+    const mediatorKernel = mediator.kernel;
+
+    const output0 = mediatorBase(0);
+    const output1 = mediatorBase(1);
+    expect(output0(0)).toBe(0);
+    expect(output0(1)).toBe(1);
+    expect(output1(0)).toBe(1);
+    expect(output1(1)).toBe(0);
+
+    const [[section, sectionWeight]] = Array.from(mediatorKernel(0).w.entries());
+    expect(sectionWeight).toBeCloseTo(1);
+    expect(section(0)).toBe(0);
+    expect(section(1)).toBe(1);
+
+    const duplicate = witness.factor<number>([
+      { index: 0, base: (input) => input },
+      { index: 0, base: (input) => input },
+    ]);
+    expect(duplicate.ok).toBe(false);
+    expect(duplicate.failures[0]?.index).toBe(0);
+
+    const familyWithoutExtend = { ...family, extend: undefined as typeof family.extend };
+    const witnessWithoutExtend = buildDeterministicKolmogorovProductWitness(createInfObj(familyWithoutExtend));
+    const failure = witnessWithoutExtend.factor<number>([{ index: 0, base: (input) => input }]);
+    expect(failure.ok).toBe(false);
+    expect(failure.details).toContain("extension builder");
+  });
+
+  it("certifies deterministic mediators for Kolmogorov products", () => {
+    type Input = "L" | "R";
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const obj = createInfObj(family);
+    const witness = obj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(obj);
+
+    const domainFin = mkFin<Input>(["L", "R"], (a, b) => a === b);
+    const domainWitness = buildMarkovComonoidWitness(domainFin, { label: "inputs" });
+    const bitFin = mkFin([0, 1], (a, b) => a === b);
+    const bitWitness = buildMarkovComonoidWitness(bitFin, { label: "bit" });
+
+    const bit0 = (input: Input) => (input === "L" ? 0 : 1);
+    const bit1 = (input: Input) => (input === "L" ? 1 : 0);
+
+    const components = [
+      {
+        index: 0,
+        arrow: detK(domainFin, bitFin, bit0),
+        witness: bitWitness,
+        base: bit0,
+        label: "first",
+      },
+      {
+        index: 1,
+        arrow: detK(domainFin, bitFin, bit1),
+        witness: bitWitness,
+        base: bit1,
+        label: "second",
+      },
+    ];
+
+    const mediator = witness.factor<Input>(components.map(({ index, base }) => ({ index, base })));
+    expect(mediator.ok).toBe(true);
+    if (!mediator.ok || !mediator.base) {
+      throw new Error("Expected deterministic mediator");
+    }
+
+    const result = checkDeterministicProductUniversalProperty(
+      witness,
+      { base: mediator.base, label: "swap" },
+      indices,
+      {
+        domain: domainWitness,
+        components,
+        samples: domainWitness.object.elems,
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.mediatorAgreement).toBe(true);
+    expect(result.components.every((entry) => entry.ok)).toBe(true);
+    expect(result.positive).toBe(true);
+  });
+
+  it("reports failures for non-deterministic component arrows", () => {
+    type Input = "L" | "R";
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const obj = createInfObj(family);
+    const witness = obj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(obj);
+
+    const domainFin = mkFin<Input>(["L", "R"], (a, b) => a === b);
+    const domainWitness = buildMarkovComonoidWitness(domainFin, { label: "inputs" });
+    const bitFin = mkFin([0, 1], (a, b) => a === b);
+    const bitWitness = buildMarkovComonoidWitness(bitFin, { label: "bit" });
+
+    const bit0 = (input: Input) => (input === "L" ? 0 : 1);
+    const bit1 = (input: Input) => (input === "L" ? 1 : 0);
+    const noisy = fromMatrix(domainFin, bitFin, [
+      [0.5, 0.5],
+      [0, 1],
+    ]);
+
+    const components = [
+      { index: 0, arrow: noisy, witness: bitWitness, base: bit0, label: "noisy" },
+      { index: 1, arrow: detK(domainFin, bitFin, bit1), witness: bitWitness, base: bit1, label: "second" },
+    ];
+
+    const extend = family.extend!;
+    const candidateBase = (input: Input) =>
+      extend(
+        indices,
+        new Map<number, number>([
+          [0, bit0(input)],
+          [1, bit1(input)],
+        ])
+      );
+
+    const result = checkDeterministicProductUniversalProperty(
+      witness,
+      { base: candidateBase, label: "placeholder" },
+      indices,
+      {
+        domain: domainWitness,
+        components,
+        samples: domainWitness.object.elems,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.components.find((entry) => entry.index === 0)?.ok).toBe(false);
+    expect(result.factorization.ok).toBe(false);
+    expect(result.factorization.failures.some((failure) => failure.index === 0)).toBe(true);
+  });
+
+  it("detects mediator mismatches and uniqueness conflicts", () => {
+    type Input = "L" | "R";
+    const indices = [0, 1];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const obj = createInfObj(family);
+    const witness = obj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(obj);
+
+    const domainFin = mkFin<Input>(["L", "R"], (a, b) => a === b);
+    const domainWitness = buildMarkovComonoidWitness(domainFin, { label: "inputs" });
+    const bitFin = mkFin([0, 1], (a, b) => a === b);
+    const bitWitness = buildMarkovComonoidWitness(bitFin, { label: "bit" });
+
+    const bit0 = (input: Input) => (input === "L" ? 0 : 1);
+    const bit1 = (input: Input) => (input === "L" ? 1 : 0);
+
+    const components = [
+      { index: 0, arrow: detK(domainFin, bitFin, bit0), witness: bitWitness, base: bit0, label: "first" },
+      { index: 1, arrow: detK(domainFin, bitFin, bit1), witness: bitWitness, base: bit1, label: "second" },
+    ];
+
+    const mediator = witness.factor<Input>(components.map(({ index, base }) => ({ index, base })));
+    expect(mediator.ok).toBe(true);
+    if (!mediator.ok || !mediator.base) {
+      throw new Error("Expected deterministic mediator");
+    }
+
+    const extend = family.extend!;
+    const mismatchingBase = (input: Input) =>
+      extend(
+        indices,
+        new Map<number, number>([
+          [0, bit0(input)],
+          [1, 0],
+        ])
+      );
+
+    const result = checkDeterministicProductUniversalProperty(
+      witness,
+      { base: mismatchingBase, label: "mismatch" },
+      indices,
+      {
+        domain: domainWitness,
+        components,
+        samples: domainWitness.object.elems,
+        alternate: { base: mediator.base, label: "reference" },
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.mediatorAgreement).toBe(false);
+    expect(result.mismatches.length).toBeGreaterThan(0);
+    expect(result.uniqueness?.ok).toBe(false);
+    expect(result.uniqueness?.mismatches.length).toBeGreaterThan(0);
+  });
+
+  it("supports partitions and tensor Kolmogorov products", () => {
+    type Input = "L" | "R";
+    const indices = [0, 1, 2];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+      positivity: { kind: "positive", indices },
+    });
+    const obj = createInfObj(family);
+    const witness = obj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(obj);
+
+    const domainFin = mkFin<Input>(["L", "R"], (a, b) => a === b);
+    const domainWitness = buildMarkovComonoidWitness(domainFin, { label: "inputs" });
+    const bitFin = mkFin([0, 1], (a, b) => a === b);
+    const bitWitness = buildMarkovComonoidWitness(bitFin, { label: "bit" });
+
+    const bit0 = (input: Input) => (input === "L" ? 0 : 1);
+    const bit1 = (input: Input) => (input === "L" ? 1 : 0);
+    const bit2 = (input: Input) => (input === "L" ? 1 : 1);
+
+    const components = [
+      { index: 0, arrow: detK(domainFin, bitFin, bit0), witness: bitWitness, base: bit0, label: "first" },
+      { index: 1, arrow: detK(domainFin, bitFin, bit1), witness: bitWitness, base: bit1, label: "second" },
+      { index: 2, arrow: detK(domainFin, bitFin, bit2), witness: bitWitness, base: bit2, label: "third" },
+    ];
+
+    const mediator = witness.factor<Input>(components.map(({ index, base }) => ({ index, base })));
+    expect(mediator.ok).toBe(true);
+    if (!mediator.ok || !mediator.base) {
+      throw new Error("Expected deterministic mediator");
+    }
+
+    const partitionResult = checkDeterministicProductUniversalProperty(
+      witness,
+      { base: mediator.base, label: "partition mediator" },
+      indices,
+      {
+        domain: domainWitness,
+        components,
+        samples: domainWitness.object.elems,
+        partitions: [[0, 1], [2]],
+      }
+    );
+
+    expect(partitionResult.ok).toBe(true);
+    expect(partitionResult.partitions?.every((report) => report.ok)).toBe(true);
+
+    const left = independentInfObj(
+      Prob,
+      [0],
+      () => bernoulli(0.5),
+      { measurability: discreteWitness([0]), positivity: { kind: "positive", indices: [0] } }
+    );
+    const right = independentInfObj(
+      Prob,
+      [0, 1],
+      () => bernoulli(0.5),
+      { measurability: discreteWitness([0, 1]), positivity: { kind: "positive", indices: [0, 1] } }
+    );
+    const tensor = tensorKolmogorovProducts(left, right);
+    const tensorWitness = tensor.infObj.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(tensor.infObj);
+
+    const tensorIndices = [tensor.toLeft(0), tensor.toRight(0), tensor.toRight(1)] as const;
+
+    const leftBit = (input: Input) => (input === "L" ? 0 : 1);
+    const rightBit0 = (input: Input) => (input === "L" ? 1 : 0);
+    const rightBit1 = (input: Input) => (input === "L" ? 0 : 1);
+
+    const tensorComponents = [
+      { index: tensor.toLeft(0), arrow: detK(domainFin, bitFin, leftBit), witness: bitWitness, base: leftBit, label: "left" },
+      { index: tensor.toRight(0), arrow: detK(domainFin, bitFin, rightBit0), witness: bitWitness, base: rightBit0, label: "right0" },
+      { index: tensor.toRight(1), arrow: detK(domainFin, bitFin, rightBit1), witness: bitWitness, base: rightBit1, label: "right1" },
+    ];
+
+    const leftWitness = left.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(left);
+    const rightWitness = right.deterministicWitness?.() ?? buildDeterministicKolmogorovProductWitness(right);
+
+    const leftMediator = leftWitness.factor<Input>([
+      { index: 0, base: leftBit },
+    ]);
+    const rightMediator = rightWitness.factor<Input>([
+      { index: 0, base: rightBit0 },
+      { index: 1, base: rightBit1 },
+    ]);
+
+    if (!leftMediator.ok || !leftMediator.base || !rightMediator.ok || !rightMediator.base) {
+      throw new Error("Expected component mediators for tensor factors");
+    }
+
+    const leftBase = leftMediator.base;
+    const rightBase = rightMediator.base;
+    type LeftCarrier = ReturnType<typeof leftBase>;
+    type RightCarrier = ReturnType<typeof rightBase>;
+
+    const tensorCandidateBase = (input: Input): TensorCarrier<LeftCarrier, RightCarrier> => [
+      leftBase(input),
+      rightBase(input),
+    ];
+
+    const tensorResult = checkDeterministicProductUniversalProperty(
+      tensorWitness,
+      { base: tensorCandidateBase, label: "tensor mediator" },
+      tensorIndices,
+      {
+        domain: domainWitness,
+        components: tensorComponents,
+        samples: domainWitness.object.elems,
+        partitions: [[tensor.toLeft(0)], [tensor.toRight(0), tensor.toRight(1)]],
+      }
+    );
+
+    expect(tensorResult.ok).toBe(true);
+    expect(tensorResult.mediatorAgreement).toBe(true);
+    expect(tensorResult.components.every((entry) => entry.ok)).toBe(true);
+  });
+
+  it("restricts projective families to subsets", () => {
+    const indices = [0, 1, 2, 3];
+    const family = independentIndexedProduct(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const subset = [0, 2];
+    const restricted = restrictProjectiveFamily(family, subset);
+
+    expect(Array.from(restricted.index)).toEqual(subset);
+    expect(restricted.countability?.sample).toEqual([0, 2]);
+    expect(restricted.measurability?.coordinates?.length).toBe(2);
+
+    const originalMarginal = family.marginal(subset);
+    const restrictedMarginal = restricted.marginal(subset);
+    expect(equalDist(Prob, originalMarginal, restrictedMarginal)).toBe(true);
+
+    const restrictedObj = restrictInfObj(createInfObj(family), subset);
+    const sample: ProjectiveLimitSection<number, number> = (index) => (subset.includes(index) ? 1 : 0);
+    const projection = restrictedObj.projectKernel(subset)(sample);
+    const [[section]] = Array.from(projection.w.entries());
+    expect(section.get(0)).toBe(1);
+    expect(section.get(2)).toBe(1);
+  });
+
+  it("reconstructs double-indexed independent products", () => {
+    type Outer = "A" | "B";
+    type Inner = 0 | 1;
+
+    const outer: Outer[] = ["A", "B"];
+    const inner = (index: Outer): ReadonlyArray<Inner> => (index === "A" ? [0, 1] : [0, 1]);
+    const coordinate = (index: Outer, sub: Inner) =>
+      index === "A" ? bernoulli(sub === 0 ? 0.2 : 0.8) : bernoulli(sub === 0 ? 0.6 : 0.4);
+
+    const result = independentDoubleIndexedProduct(Prob, outer, inner, coordinate);
+    const { family, toIndex, innerFamilies } = result;
+
+    const subset: Array<DoubleIndex<Outer, Inner>> = [toIndex("A", 0), toIndex("B", 1)];
+    const direct = family.marginal(subset);
+
+    const combine = () => {
+      type Entry = { section: Map<DoubleIndex<Outer, Inner>, number>; weight: number };
+      let acc: Entry[] = [{ section: new Map(), weight: 1 }];
+
+      for (const outerKey of outer) {
+        const marginal = innerFamilies.get(outerKey)!.marginal(
+          subset.filter((entry) => entry.outer === outerKey).map((entry) => entry.inner)
+        );
+        const next: Entry[] = [];
+        marginal.w.forEach((weight, section) => {
+          for (const entry of acc) {
+            const combined = new Map(entry.section);
+            section.forEach((value, innerIndex) => {
+              combined.set(toIndex(outerKey, innerIndex), value);
+            });
+            next.push({ section: combined, weight: entry.weight * weight });
+          }
+        });
+        acc = next;
+      }
+
+      const expected: Dist<number, CylinderSection<DoubleIndex<Outer, Inner>, number>> = { R: Prob, w: new Map() };
+      for (const entry of acc) {
+        expected.w.set(new Map(entry.section), entry.weight);
+      }
+      return expected;
+    };
+
+    const expected = combine();
+    expect(equalDist(Prob, direct, expected)).toBe(true);
+
+    const nested = new Map<Outer, CylinderSection<Inner, number>>([
+      ["A", new Map<Inner, number>([[0, 1]])],
+      ["B", new Map<Inner, number>([[1, 0]])],
+    ]);
+    const flattened = flattenNestedCylinder(nested, toIndex);
+    expect(flattened.get(toIndex("A", 0))).toBe(1);
+    expect(flattened.get(toIndex("B", 1))).toBe(0);
+  });
+
+  it("tensors Kolmogorov products via double-index flattening", () => {
+    const leftIndices = [0, 1];
+    const rightIndices = [0, 1];
+
+    const leftObj = createInfObj(
+      independentIndexedProduct(Prob, leftIndices, () => bernoulli(0.5), {
+        measurability: discreteWitness(leftIndices),
+        positivity: { kind: "positive", indices: leftIndices },
+      }),
+    );
+    const rightObj = createInfObj(
+      independentIndexedProduct(Prob, rightIndices, () => bernoulli(0.25), {
+        measurability: discreteWitness(rightIndices),
+        positivity: { kind: "positive", indices: rightIndices },
+      }),
+    );
+
+    const tensor = tensorKolmogorovProducts(leftObj, rightObj);
+    const leftIndex0 = tensor.toLeft(0);
+    const rightIndex0 = tensor.toRight(0);
+
+    const subsets: Array<ReadonlyArray<TensorIndex<number, number>>> = [
+      [leftIndex0],
+      [rightIndex0],
+      [leftIndex0, rightIndex0],
+    ];
+
+    const samples: Array<TensorCarrier<ProjectiveLimitSection<number, number>, ProjectiveLimitSection<number, number>>> = [
+      [
+        (i) => (i === 0 ? 0 : 1),
+        (i) => (i === 0 ? 1 : 0),
+      ],
+      [
+        (i) => (i === 0 ? 1 : 0),
+        (i) => (i === 0 ? 0 : 1),
+      ],
+    ];
+
+    const result = checkKolmogorovProduct(tensor.infObj, subsets, samples);
+    expect(result.ok).toBe(true);
+    expect(result.deterministic).toBe(true);
+    expect(result.copyDiscard.ok).toBe(true);
+    expect(tensor.family.countability?.kind).toBe("finite");
+    expect(tensor.family.measurability?.kind).toBe("standardBorel");
+    expect(tensor.infObj.positivity?.kind ?? tensor.family.positivity?.kind).toBe("positive");
+  });
+
+  it("detects tail invariance violations", () => {
+    const indices = Array.from({ length: 6 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const delta = dirac(Prob);
+
+    const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+    const singleOne: ProjectiveLimitSection<number, number> = (i) => (i === 0 ? 1 : 0);
+
+    const tailEvent = (section: ProjectiveLimitSection<number, number>) =>
+      delta(section(5) === 0);
+
+    const patches = [new Map<number, number>([[0, 1]]), new Map<number, number>([[5, 1]])];
+    const invariance = checkTailEventInvariance(obj, tailEvent, [constantZero, singleOne], patches);
+    expect(invariance.ok).toBe(false);
+    expect(invariance.counterexamples.length).toBeGreaterThan(0);
+    expect(invariance.countable).toBe(true);
+    expect(invariance.witness?.kind).toBeDefined();
+    expect(invariance.measurable).toBe(true);
+    expect(invariance.standardBorel).toBe(true);
+  });
+
+  it("produces Kolmogorov zero-one witnesses", () => {
+    const indices = Array.from({ length: 4 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const delta = dirac(Prob);
+
+    const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+    const measure = makeMeasure([[constantZero, 1]]);
+
+    const tailEvent = (section: ProjectiveLimitSection<number, number>) => delta(section(3) === 0);
+    const witness = kolmogorovZeroOneWitness(obj, measure, tailEvent);
+    expect(witness.ok).toBe(true);
+    expect(witness.probability).toBeCloseTo(1);
+    expect(witness.countable).toBe(true);
+    expect(witness.witness?.kind).toBeDefined();
+    expect(witness.measurable).toBe(true);
+    expect(witness.standardBorel).toBe(true);
+  });
+
+  it("certifies independence between tail events and finite marginals", () => {
+    const indices = Array.from({ length: 5 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const extension = kolmogorovExtensionMeasure(obj.family, [[0], [1], [2], [3], [4]]);
+    if (!extension.ok) {
+      throw new Error(`Kolmogorov extension failed: ${extension.reason}`);
+    }
+
+    const delta = dirac(Prob);
+    const tailEvent = (section: ProjectiveLimitSection<number, number>) => delta(section(4) === 0);
+    const subsets: Array<FiniteSubset<number>> = [[0], [0, 1], [2, 3]];
+
+    const report = checkTailSigmaIndependence(obj, extension.measure, tailEvent, subsets);
+    expect(report.ok).toBe(true);
+    expect(report.countable).toBe(true);
+    expect(report.measurable).toBe(true);
+    expect(report.standardBorel).toBe(true);
+    report.subsets.forEach((subsetReport) => {
+      expect(subsetReport.errors.length).toBe(0);
+      subsetReport.sections.forEach((section) => expect(section.ok).toBe(true));
+    });
+  });
+
+  it("detects dependence when the event matches a finite marginal", () => {
+    const indices = Array.from({ length: 5 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const extension = kolmogorovExtensionMeasure(obj.family, [[0], [1], [2]]);
+    if (!extension.ok) {
+      throw new Error(`Kolmogorov extension failed: ${extension.reason}`);
+    }
+
+    const delta = dirac(Prob);
+    const headEvent = (section: ProjectiveLimitSection<number, number>) => delta(section(0) === 0);
+    const result = checkTailSigmaIndependence(obj, extension.measure, headEvent, [[0]]);
+    expect(result.ok).toBe(false);
+    expect(result.subsets[0]?.errors.length).toBe(0);
+    const failing = result.subsets[0]?.sections.some((entry) => !entry.ok) ?? false;
+    expect(failing).toBe(true);
+  });
+
+  it("verifies the abstract Kolmogorov zero-one law via witnesses", () => {
+    const fixtures = buildZeroOneFixtures();
+
+    const tailArrow = detK(fixtures.carrierFin, fixtures.boolFin, () => 1);
+    const deterministicWitness = buildMarkovDeterministicWitness(fixtures.carrierWitness, fixtures.boolWitness, tailArrow, {
+      label: "constant tail statistic",
+    });
+
+    const jointKernel = pair(fixtures.p.k, fixtures.p.then(tailArrow).k);
+    const joint = new FinMarkov(
+      fixtures.domainFin,
+      tensorObj(fixtures.carrierFin, fixtures.boolFin),
+      jointKernel,
+    );
+    const conditional = buildMarkovConditionalWitness(
+      fixtures.domainWitness,
+      [fixtures.carrierWitness, fixtures.boolWitness],
+      joint,
+      { label: "joint with constant tail" },
+    );
+
+    const lemma = {
+      conditional,
+      p: fixtures.p,
+      deterministic: deterministicWitness,
+      xIndex: 0,
+      tIndex: 1,
+      label: "constant tail lemma",
+    };
+
+    const measure = makeMeasure([
+      [fixtures.constantZero, 0.5],
+      [fixtures.constantOne, 0.5],
+    ]);
+
+    const tailEvent = asDeterministicKernel(Prob, () => true);
+
+    const zeroOneWitness = {
+      product: fixtures.productWitness,
+      domain: fixtures.domainWitness,
+      measure,
+      tailEvent,
+      determinismLemma: lemma,
+      tailConditional: conditional,
+    };
+
+    const result = checkKolmogorovZeroOneLaw(zeroOneWitness, {
+      subsets: [[0], [1, 2]],
+      lemma: { tolerance: 1e-9 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.zeroOne.ok).toBe(true);
+    expect(result.tail.ok).toBe(true);
+    expect(result.determinism?.holds).toBe(true);
+    expect(result.tailConditional?.holds).toBe(true);
+  });
+
+  it("detects failures in the abstract Kolmogorov zero-one law hypotheses", () => {
+    const fixtures = buildZeroOneFixtures();
+
+    const tailArrow = detK(fixtures.carrierFin, fixtures.boolFin, (section) => (section(0) === 0 ? 1 : 0));
+    const deterministicWitness = buildMarkovDeterministicWitness(fixtures.carrierWitness, fixtures.boolWitness, tailArrow, {
+      label: "first coordinate statistic",
+    });
+
+    const jointKernel = pair(fixtures.p.k, fixtures.p.then(tailArrow).k);
+    const joint = new FinMarkov(
+      fixtures.domainFin,
+      tensorObj(fixtures.carrierFin, fixtures.boolFin),
+      jointKernel,
+    );
+    const conditional = buildMarkovConditionalWitness(
+      fixtures.domainWitness,
+      [fixtures.carrierWitness, fixtures.boolWitness],
+      joint,
+      { label: "joint with correlated tail" },
+    );
+
+    const lemma = {
+      conditional,
+      p: fixtures.p,
+      deterministic: deterministicWitness,
+      xIndex: 0,
+      tIndex: 1,
+      label: "correlated tail lemma",
+    };
+
+    const measure = makeMeasure([
+      [fixtures.constantZero, 0.5],
+      [fixtures.constantOne, 0.5],
+    ]);
+
+    const tailEvent = asDeterministicKernel(Prob, (section: ProjectiveLimitSection<number, number>) => section(0) === 0);
+
+    const zeroOneWitness = {
+      product: fixtures.productWitness,
+      domain: fixtures.domainWitness,
+      measure,
+      tailEvent,
+      determinismLemma: lemma,
+      tailConditional: conditional,
+    };
+
+    const result = checkKolmogorovZeroOneLaw(zeroOneWitness, {
+      subsets: [[0]],
+      lemma: { tolerance: 1e-9 },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.zeroOne.ok).toBe(false);
+    expect(result.tail.ok).toBe(false);
+  });
+
+  it("combines Kolmogorov and Hewitt–Savage zero-one diagnostics", () => {
+    const fixtures = buildZeroOneFixtures();
+
+    const tailArrow = detK(fixtures.carrierFin, fixtures.boolFin, () => 1);
+    const deterministicWitness = buildMarkovDeterministicWitness(fixtures.carrierWitness, fixtures.boolWitness, tailArrow, {
+      label: "constant tail statistic",
+    });
+
+    const jointKernel = pair(fixtures.p.k, fixtures.p.then(tailArrow).k);
+    const joint = new FinMarkov(
+      fixtures.domainFin,
+      tensorObj(fixtures.carrierFin, fixtures.boolFin),
+      jointKernel,
+    );
+    const conditional = buildMarkovConditionalWitness(
+      fixtures.domainWitness,
+      [fixtures.carrierWitness, fixtures.boolWitness],
+      joint,
+      { label: "joint with constant tail" },
+    );
+
+    const lemma = {
+      conditional,
+      p: fixtures.p,
+      deterministic: deterministicWitness,
+      xIndex: 0,
+      tIndex: 1,
+      label: "constant tail lemma",
+    };
+
+    const measure = makeMeasure([
+      [fixtures.constantZero, 0.5],
+      [fixtures.constantOne, 0.5],
+    ]);
+
+    const tailEvent = asDeterministicKernel(Prob, () => true);
+
+    const swap01 = (section: ProjectiveLimitSection<number, number>) => section;
+
+    const hewittWitness = {
+      product: fixtures.productWitness,
+      domain: fixtures.domainWitness,
+      measure,
+      tailEvent,
+      determinismLemma: lemma,
+      tailConditional: conditional,
+      permutations: [swap01],
+    };
+
+    const result = checkHewittSavageZeroOneLaw(hewittWitness, {
+      subsets: [[0], [1, 2]],
+      lemma: { tolerance: 1e-9 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.exchangeability.ok).toBe(true);
+    expect(result.zeroOne.ok).toBe(true);
+    expect(result.determinism?.holds).toBe(true);
+  });
+
+  it("flags zero-one failures", () => {
+    const indices = Array.from({ length: 4 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const delta = dirac(Prob);
+
+    const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+    const constantOne: ProjectiveLimitSection<number, number> = () => 1;
+    const measure = makeMeasure([
+      [constantZero, 0.5],
+      [constantOne, 0.5],
+    ]);
+
+    const headEvent = (section: ProjectiveLimitSection<number, number>) => delta(section(0) === 0);
+    const witness = kolmogorovZeroOneWitness(obj, measure, headEvent);
+    expect(witness.ok).toBe(false);
+    expect(witness.countable).toBe(true);
+    expect(witness.measurable).toBe(true);
+    expect(witness.standardBorel).toBe(true);
+  });
+
+  it("checks Hewitt–Savage zero-one witness and exchangeability", () => {
+    const indices = Array.from({ length: 4 }, (_, i) => i);
+    const obj = independentInfObj(Prob, indices, () => bernoulli(0.5), {
+      measurability: discreteWitness(indices),
+    });
+    const delta = dirac(Prob);
+
+    const constantZero: ProjectiveLimitSection<number, number> = () => 0;
+    const constantOne: ProjectiveLimitSection<number, number> = () => 1;
+    const measure = makeMeasure([
+      [constantZero, 0.5],
+      [constantOne, 0.5],
+    ]);
+
+    const swap01 = (section: ProjectiveLimitSection<number, number>) => {
+      if (section === constantZero || section === constantOne) {
+        return section;
+      }
+      return (index: number) => (index === 0 ? section(1) : index === 1 ? section(0) : section(index));
+    };
+
+    const tailEvent = (section: ProjectiveLimitSection<number, number>) => delta(true);
+    const witness = hewittSavageZeroOneWitness(obj, measure, tailEvent, [swap01]);
+    expect(witness.ok).toBe(true);
+    expect(witness.exchangeable).toBe(true);
+    expect(witness.invariant).toBe(true);
+    expect(witness.probability).toBeCloseTo(1);
+    expect(witness.countable).toBe(true);
+    expect(witness.witness?.kind).toBeDefined();
+    expect(witness.measurable).toBe(true);
+    expect(witness.standardBorel).toBe(true);
+  });
+
+  it("spots the Example 3.7 obstruction for FinStoch families", () => {
+    const infiniteIndices: Iterable<number> = {
+      [Symbol.iterator]: function* () {
+        let i = 0;
+        while (true) {
+          yield i;
+          i += 1;
+        }
+      },
+    };
+
+    const analysis = analyzeFinStochInfiniteTensor(
+      infiniteIndices,
+      (index) => (index % 2 === 0 ? mkFin(["a", "b"]) : mkFin(["a"])),
+      { sampleLimit: 64, threshold: 16 }
+    );
+
+    expect(analysis.status).toBe("likelyObstructed");
+    expect(analysis.truncated).toBe(true);
+    expect(analysis.emptyFactors.length).toBe(0);
+    expect(analysis.multiValuedCount).toBeGreaterThanOrEqual(16);
+
+    const finiteIndices = [0, 1, 2];
+    const finiteAnalysis = analyzeFinStochInfiniteTensor(
+      finiteIndices,
+      (index) => (index === 0 ? mkFin(["a", "b"]) : mkFin(["a"]))
+    );
+
+    expect(finiteAnalysis.status).toBe("ok");
+    expect(finiteAnalysis.exhausted).toBe(true);
+    expect(finiteAnalysis.truncated).toBe(false);
+
+    const emptyAnalysis = analyzeFinStochInfiniteTensor(
+      [0, 1],
+      (index) => (index === 0 ? mkFin<string>([]) : mkFin(["a"]))
+    );
+
+    expect(emptyAnalysis.status).toBe("obstructed");
+    expect(emptyAnalysis.emptyFactors.length).toBeGreaterThan(0);
+  });
+});

--- a/test/laws/law.SemicartesianCRingPlus.spec.ts
+++ b/test/laws/law.SemicartesianCRingPlus.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import {
+  IntegersObject,
+  createModObject,
+  canonicalInitialHom,
+  checkCRingPlusInitialSemicartesian,
+  checkAdditiveUnitHom,
+  equalHom,
+  semicartesianStructureCRingPlus,
+  type CRingPlusHom,
+} from "../../cring-plus";
+
+import type { InitialArrowSample } from "../../semicartesian-structure";
+
+describe("LAW 2.3: ℤ initial object yields semicartesian structure in CRing_⊕", () => {
+  const mod5 = createModObject(5n);
+  const canonicalToMod5 = canonicalInitialHom(mod5);
+  const canonicalToZ = canonicalInitialHom(IntegersObject);
+
+  const shifted: CRingPlusHom<bigint, bigint> = {
+    source: IntegersObject,
+    target: mod5,
+    map: (value) => mod5.ring.add(canonicalToMod5.map(value), mod5.ring.one),
+    label: "shift+1",
+  };
+
+  const samples: InitialArrowSample<any, any>[] = [
+    { target: mod5, candidate: canonicalToMod5, shouldHold: true, label: "canonical ℤ→ℤ/5ℤ" },
+    { target: IntegersObject, candidate: canonicalToZ, shouldHold: true, label: "canonical ℤ→ℤ" },
+    { target: mod5, candidate: shifted, shouldHold: false, label: "non-unital shift" },
+  ];
+
+  it("oracle validates semicartesian structure with witness reuse", () => {
+    const result = checkCRingPlusInitialSemicartesian([IntegersObject, mod5], samples);
+    expect(result.holds).toBe(true);
+    expect(result.failures).toHaveLength(0);
+
+    const witnessMap = result.witness.globalElement(mod5);
+    expect(equalHom(witnessMap, canonicalToMod5)).toBe(true);
+  });
+
+  it("canonical hom is additive and unit-preserving", () => {
+    const check = checkAdditiveUnitHom(canonicalToMod5);
+    expect(check.holds).toBe(true);
+    expect(check.failures).toHaveLength(0);
+  });
+
+  it("shifted hom fails additive/unit oracle", () => {
+    const check = checkAdditiveUnitHom(shifted);
+    expect(check.holds).toBe(false);
+  });
+
+  it("semicartesian witness composes with fast-check samples", () => {
+    const structure = semicartesianStructureCRingPlus();
+    const witnessMap = structure.globalElement(mod5);
+    fc.assert(
+      fc.property(fc.bigInt({ min: -4n, max: 4n }), fc.bigInt({ min: -4n, max: 4n }), (a, b) => {
+        const lhs = witnessMap.map(a + b);
+        const rhs = mod5.ring.add(witnessMap.map(a), witnessMap.map(b));
+        expect(mod5.ring.eq(lhs, rhs)).toBe(true);
+      })
+    );
+  });
+});

--- a/test/laws/law.SemicartesianInfiniteProduct.spec.ts
+++ b/test/laws/law.SemicartesianInfiniteProduct.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import {
+  type FiniteSubset,
+  type SemicartesianCone,
+  type SemicartesianProductWitness,
+  type SemicartesianTensorDiagram,
+  checkSemicartesianProductCone,
+  checkSemicartesianUniversalProperty,
+} from "../../semicartesian-infinite-product";
+
+type Index = "A" | "B" | "C";
+
+type Assignment = Map<Index, string>;
+
+type FiniteSet = {
+  readonly label: string;
+  readonly elements: ReadonlyArray<Assignment>;
+};
+
+type SetMorphism = {
+  readonly source: FiniteSet;
+  readonly target: FiniteSet;
+  readonly map: (value: Assignment) => Assignment;
+};
+
+const baseValues: Record<Index, readonly string[]> = {
+  A: ["a0", "a1"],
+  B: ["b0", "b1"],
+  C: ["c0", "c1"],
+};
+
+const mapEquals = (left: Assignment, right: Assignment): boolean => {
+  if (left.size !== right.size) return false;
+  for (const [key, value] of left) {
+    if (!right.has(key)) return false;
+    if (right.get(key) !== value) return false;
+  }
+  return true;
+};
+
+const copyMap = (assignment: Assignment): Assignment => new Map(assignment);
+
+const enumerateAssignments = (subset: FiniteSubset<Index>): Assignment[] => {
+  const result: Assignment[] = [];
+  const keys = [...subset];
+  const explore = (offset: number, current: Assignment) => {
+    if (offset >= keys.length) {
+      result.push(copyMap(current));
+      return;
+    }
+    const key = keys[offset];
+    for (const value of baseValues[key]) {
+      current.set(key, value);
+      explore(offset + 1, current);
+      current.delete(key);
+    }
+  };
+  explore(0, new Map());
+  return result;
+};
+
+const restrictAssignment = (assignment: Assignment, subset: FiniteSubset<Index>): Assignment => {
+  const next: Assignment = new Map();
+  for (const key of subset) {
+    const value = assignment.get(key);
+    if (value !== undefined) next.set(key, value);
+  }
+  return next;
+};
+
+const subsetKey = (subset: FiniteSubset<Index>): string => subset.join(",");
+
+const makeSet = (subset: FiniteSubset<Index>): FiniteSet => ({
+  label: subsetKey(subset) || "∅",
+  elements: enumerateAssignments(subset),
+});
+
+const createMorphism = (
+  source: FiniteSet,
+  target: FiniteSet,
+  map: (value: Assignment) => Assignment,
+): SetMorphism => ({ source, target, map });
+
+const compose = (first: SetMorphism, second: SetMorphism): SetMorphism => ({
+  source: first.source,
+  target: second.target,
+  map: (value) => second.map(first.map(value)),
+});
+
+const equal = (a: SetMorphism, b: SetMorphism): boolean => {
+  if (a.source.label !== b.source.label || a.target.label !== b.target.label) return false;
+  for (const value of a.source.elements) {
+    const left = a.map(value);
+    const right = b.map(value);
+    if (!mapEquals(left, right)) return false;
+  }
+  return true;
+};
+
+const indices: Index[] = ["A", "B", "C"];
+const tensorCache = new Map<string, FiniteSet>();
+
+const getSet = (subset: FiniteSubset<Index>): FiniteSet => {
+  const key = subsetKey(subset);
+  const cached = tensorCache.get(key);
+  if (cached) return cached;
+  const created = makeSet(subset);
+  tensorCache.set(key, created);
+  return created;
+};
+
+const diagram: SemicartesianTensorDiagram<Index, FiniteSet, SetMorphism> = {
+  index: indices,
+  tensor: getSet,
+  restriction: (larger, smaller) => createMorphism(
+    getSet(larger),
+    getSet(smaller),
+    (value) => restrictAssignment(value, smaller),
+  ),
+  compose,
+  equal,
+  describeSubset: subsetKey,
+  describeMorphism: (morphism) => `${morphism.source.label}→${morphism.target.label}`,
+};
+
+const productSet = getSet(indices);
+
+const productWitness: SemicartesianProductWitness<Index, FiniteSet, SetMorphism> = {
+  object: productSet,
+  diagram,
+  projection: (subset) => createMorphism(
+    productSet,
+    getSet(subset),
+    (value) => restrictAssignment(value, subset),
+  ),
+  factor: (cone) => ({
+    mediator: createMorphism(
+      cone.apex,
+      productSet,
+      (value) => {
+        const result: Assignment = new Map();
+        for (const index of indices) {
+          const singleton = [index] as const;
+          const image = cone.leg(singleton).map(value);
+          const valueAtIndex = image.get(index);
+          if (valueAtIndex === undefined) {
+            throw new Error(`Cone leg for ${index} omitted value.`);
+          }
+          result.set(index, valueAtIndex);
+        }
+        return result;
+      },
+    ),
+  }),
+  label: "Product of A,B,C",
+};
+
+describe("Semicartesian infinite tensor products", () => {
+  it("confirms projection compatibility across finite subsets", () => {
+    const restrictions = [
+      { larger: ["A", "B"], smaller: ["A"] },
+      { larger: ["A", "B"], smaller: ["B"] },
+      { larger: ["A", "B", "C"], smaller: ["A", "B"] },
+      { larger: ["A", "B", "C"], smaller: ["A"] },
+      { larger: ["A", "B", "C"], smaller: ["C"] },
+    ] satisfies ReadonlyArray<{ larger: FiniteSubset<Index>; smaller: FiniteSubset<Index> }>;
+
+    const result = checkSemicartesianProductCone(productWitness, restrictions);
+    expect(result.holds).toBe(true);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("produces unique mediators for compatible cones", () => {
+    const canonicalCone: SemicartesianCone<Index, FiniteSet, SetMorphism> = {
+      apex: productSet,
+      leg: productWitness.projection,
+      label: "Identity cone",
+    };
+
+    const abSet = getSet(["A", "B"]);
+    const abCone: SemicartesianCone<Index, FiniteSet, SetMorphism> = {
+      apex: abSet,
+      label: "AB with constant C",
+      leg: (subset) => {
+        const key = subsetKey(subset);
+        if (key === "A,B") return createMorphism(abSet, getSet(["A", "B"]), (value) => value);
+        if (key === "A") return createMorphism(abSet, getSet(["A"]), (value) => restrictAssignment(value, ["A"]));
+        if (key === "B") return createMorphism(abSet, getSet(["B"]), (value) => restrictAssignment(value, ["B"]));
+        if (key === "C") {
+          return createMorphism(abSet, getSet(["C"]), () => {
+            const assignment: Assignment = new Map();
+            assignment.set("C", "c0");
+            return assignment;
+          });
+        }
+        throw new Error(`Unsupported subset ${key}`);
+      },
+      mediatorCandidates: [
+        {
+          label: "default extension",
+          morphism: createMorphism(abSet, productSet, (value) => {
+            const assignment = copyMap(value);
+            assignment.set("C", "c0");
+            return assignment;
+          }),
+        },
+      ],
+    };
+
+    const subsets: ReadonlyArray<FiniteSubset<Index>> = [["A"], ["B"], ["C"], ["A", "B"]];
+    const result = checkSemicartesianUniversalProperty(productWitness, [canonicalCone, abCone], subsets);
+    expect(result.holds).toBe(true);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("flags non-unique mediators when candidate extensions disagree", () => {
+    const abSet = getSet(["A", "B"]);
+    const ambiguousCone: SemicartesianCone<Index, FiniteSet, SetMorphism> = {
+      apex: abSet,
+      label: "AB with ambiguous C",
+      leg: (subset) => {
+        const key = subsetKey(subset);
+        if (key === "A,B") return createMorphism(abSet, getSet(["A", "B"]), (value) => value);
+        if (key === "A") return createMorphism(abSet, getSet(["A"]), (value) => restrictAssignment(value, ["A"]));
+        if (key === "B") return createMorphism(abSet, getSet(["B"]), (value) => restrictAssignment(value, ["B"]));
+        return createMorphism(abSet, getSet(subset), () => {
+          const assignment: Assignment = new Map();
+          for (const index of subset) {
+            if (index === "A" || index === "B") assignment.set(index, "a0");
+            if (index === "C") assignment.set(index, "c0");
+          }
+          return assignment;
+        });
+      },
+      mediatorCandidates: [
+        {
+          label: "shift C",
+          morphism: createMorphism(abSet, productSet, (value) => {
+            const assignment = copyMap(value);
+            assignment.set("C", "c1");
+            return assignment;
+          }),
+        },
+      ],
+    };
+
+    const result = checkSemicartesianUniversalProperty(productWitness, [ambiguousCone], [["A"], ["B"]]);
+    expect(result.holds).toBe(false);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].reason).toContain("violates uniqueness");
+  });
+});

--- a/test/laws/law.SetMult.spec.ts
+++ b/test/laws/law.SetMult.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { mkFin } from "../../markov-category";
+import { buildSetMultDeterminismWitness, checkSetMultDeterminism } from "../../markov-deterministic-structure";
+import {
+  checkSetMultComonoid,
+  checkSetMultDeterministic,
+  checkSetMultInfiniteProduct,
+} from "../../setmult-oracles";
+import {
+  DeterministicSetMultWitness,
+  SetMultIndexedFamily,
+  createSetMultInfObj,
+  createSetMultObj,
+  deterministicToSetMulti,
+  kernelToSetMulti,
+  projectSetMult,
+  setMultObjFromFin,
+  setMultiToKernel,
+} from "../../setmult-category";
+
+describe("SetMult semicartesian structure", () => {
+  const boolObj = createSetMultObj<boolean>({
+    eq: (a, b) => a === b,
+    show: (value) => (value ? "⊤" : "⊥"),
+    samples: [false, true],
+    label: "Bool",
+  });
+
+  it("verifies copy/discard laws on boolean samples", () => {
+    const report = checkSetMultComonoid(boolObj, boolObj.samples ?? []);
+    expect(report.holds).toBe(true);
+    expect(report.failures).toHaveLength(0);
+  });
+});
+
+describe("SetMult determinism", () => {
+  const boolFin = mkFin([false, true], (a, b) => a === b, (value) => (value ? "⊤" : "⊥"));
+  const numberFin = mkFin([0, 1], (a, b) => a === b);
+  const boolObj = setMultObjFromFin(boolFin, "Bool");
+  const numberObj = setMultObjFromFin(numberFin, "Two");
+
+  const deterministicWitness: DeterministicSetMultWitness<boolean, number> = {
+    domain: boolObj,
+    codomain: numberObj,
+    morphism: deterministicToSetMulti(boolObj, numberObj, (value) => (value ? 1 : 0)),
+    label: "indicator",
+  };
+
+  it("confirms singleton fibres are deterministic", () => {
+    const summary = checkSetMultDeterministic(deterministicWitness, boolFin.elems);
+    expect(summary.holds).toBe(true);
+    expect(summary.report.base?.(true)).toBe(1);
+  });
+
+  it("detects multi-valued fibres", () => {
+    const multiValued: DeterministicSetMultWitness<boolean, number> = {
+      domain: boolObj,
+      codomain: numberObj,
+      morphism: (value) => (value ? new Set([0, 1]) : new Set([0])),
+      label: "partial",
+    };
+    const summary = checkSetMultDeterministic(multiValued, boolFin.elems);
+    expect(summary.holds).toBe(false);
+    expect(summary.report.counterexample).toBeDefined();
+  });
+
+  it("aligns with finite Markov kernels", () => {
+    const witness = buildSetMultDeterminismWitness(boolFin, numberFin, deterministicWitness.morphism);
+    const report = checkSetMultDeterminism(witness);
+    expect(report.holds).toBe(true);
+    const kernel = setMultiToKernel(boolFin, numberFin, witness.setWitness);
+    const support = kernelToSetMulti(numberFin, kernel);
+    for (const input of boolFin.elems) {
+      expect(support(input)).toEqual(deterministicWitness.morphism(input));
+    }
+  });
+});
+
+describe("SetMult infinite products", () => {
+  const boolFin = mkFin([false, true], (a, b) => a === b);
+  const boolObj = setMultObjFromFin(boolFin, "Bool");
+
+  it("projects tuples consistently", () => {
+    const family = {
+      index: ["x", "y"] as const,
+      coordinate: () => boolObj,
+      countability: { kind: "finite", enumerate: () => ["x", "y"] as const, sample: ["x", "y"], size: 2 },
+    } satisfies SetMultIndexedFamily<"x" | "y", boolean>;
+
+    const report = checkSetMultInfiniteProduct(family, (index) => index === "x", [
+      { subset: ["x"] },
+      { subset: ["y"] },
+      { subset: ["x", "y"] },
+    ]);
+
+    expect(report.holds).toBe(true);
+    expect(report.failures).toHaveLength(0);
+    expect(report.countability?.kind).toBe("finite");
+  });
+
+  it("detects mismatched projections", () => {
+    const family = {
+      index: ["x", "y"] as const,
+      coordinate: () => boolObj,
+    } satisfies SetMultIndexedFamily<"x" | "y", boolean>;
+
+    const report = checkSetMultInfiniteProduct(
+      family,
+      (index) => index === "x",
+      [
+        { subset: ["x"], expected: new Map([["x", false]]) },
+        { subset: ["y"], expected: new Map([["y", true]]) },
+      ],
+    );
+
+    expect(report.holds).toBe(false);
+    expect(report.failures.length).toBeGreaterThan(0);
+  });
+
+  it("exposes deterministic finite projections from the product carrier", () => {
+    const family = {
+      index: ["x", "y"] as const,
+      coordinate: () => boolObj,
+    } satisfies SetMultIndexedFamily<"x" | "y", boolean>;
+
+    const product = createSetMultInfObj(family);
+    const tuple = product.carrier((index) => (index === "x" ? true : false));
+    const projection = projectSetMult(product, ["x"]);
+    const fibre = Array.from(projection(tuple));
+
+    expect(fibre).toHaveLength(1);
+    const section = fibre[0];
+    expect(section.get("x")).toBe(true);
+    expect(product.sectionObj(["x"]).eq(section, new Map([["x", true]]))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add KolmogorovZeroOneLawWitness/HewittSavageZeroOneLawWitness helpers to expose structured zero-one diagnostics on Kolmogorov products
- implement new checkKolmogorovZeroOneLaw and checkHewittSavageZeroOneLaw oracles, register them, and document the laws
- extend the Markov infinite-product tests with passing/failing scenarios that exercise the new zero-one law reports

## Testing
- npm run typecheck
- npx vitest run test/laws/law.MarkovInfinite.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0bdfb61a883269711cb3cc7a8cb48