### PR TITLE
Recover groups from one-object groupoids

### DIFF
--- a/AI_CATEGORY_OPERATIONS_LAYER.md
+++ b/AI_CATEGORY_OPERATIONS_LAYER.md
@@ -1,0 +1,101 @@
+# Category Operations Layer
+
+The operations layer complements the oracle registry by turning proved theorems
+into actionable rewrites.  Whenever a law fires we can suggest concrete edits to
+a categorical model (or to an in-memory composite) that follow from the
+witnesses the oracle produced.  The layer is intentionally orthogonal to the
+source code – rewrites are applied to *data* (finite categories, diagrams,
+paths), not to TypeScript modules.
+
+## Concepts
+
+- **Rewrite** – a structured edit such as cancelling an inverse pair, replacing
+  a composite with an identity, or merging isomorphic subobjects.
+- **Suggestion** – a bundle of rewrites with a human readable explanation and a
+  safety level (`safe` for auto-application, `hint` for user review).
+- **Operation rule** – a small policy object that inspects a context (category,
+  composite path, focussed arrow, …) and proposes suggestions when a theorem is
+  applicable.
+- **Rewriter** – a dispatcher that evaluates a set of rules against a context
+  and collects the resulting suggestions.
+
+## Workflow
+
+1.  Collect structural witnesses via the oracle layer (e.g. `twoSidedInverses`,
+    `rightInverses`, factorisation arrows in a pullback/pushout search).
+2.  Feed the current categorical context into the `Rewriter`.
+3.  Auto-apply all `safe` suggestions (normalisation) and present `hint`
+    suggestions to the user for approval.
+4.  Optionally serialise accepted rewrites into JSON patches if the category is
+    stored outside of the TypeScript process.
+
+## Seed Rules
+
+The initial rules mirror the Chapter 8 theorems:
+
+- **Iso cancellation** – detects adjacent inverse pairs inside a composite path
+  and proposes a `NormalizeComposite` rewrite.
+- **Monic + right inverse upgrade** – when an arrow is monic and comes with a
+  right inverse, the rule suggests promoting it to an isomorphism and replacing
+  both composites with identities (Theorem 22).
+- **Epi–mono factorisation** – for any arrow that splits as an epimorphism
+  followed by a monomorphism, the rule produces a `FactorThroughEpiMono`
+  rewrite so callers can replace the original map with the two-stage
+  factorisation (Definition 37).
+- **Object iso merge** – if an actual two-sided inverse is present, treat the
+  domain and codomain objects as isomorphic and queue a merge rewrite.
+- **Mutual mono factorisation merge** – if two monomorphisms into the same
+  object factor through each other, the rule proposes merging their domains as
+  isomorphic subobjects (Theorem 23).
+
+The architecture is deliberately extensible: future rules can introduce
+pullbacks/pushouts, slice/arrow simplifications, or Beck–Chevalley rewrites by
+following the same template.
+
+## Balanced Categories
+
+A category is **balanced** when every arrow that is both monic and epic is
+automatically an isomorphism.  Operationally this acts like a global toggle:
+
+- When `category.traits?.balanced === true`, any rule that detects both
+  cancellability flags can confidently emit an `UpgradeToIso` rewrite without
+  searching for explicit inverses.
+- In non-balanced categories the same detection merely annotates the arrow – it
+  may still fail to have an inverse (cf. the `TwoObj` and `Mon` counterexamples).
+
+Balanced categories therefore turn certain oracle results into immediate
+rewrites, dramatically reducing the amount of search required in familiar
+categories such as `Set`, `Grp`, or `Vect`.
+
+## Groups and Groupoids
+
+Definition 8.7 highlights that a group can be viewed as a one-object
+groupoid and, conversely, that any one-object groupoid packages enough
+information to recover a group structure.  The implementation now supports
+both directions:
+
+- `catFromGroup` turns a finite group into a category with a single object
+  whose arrows are exactly the group elements.
+- `groupFromOneObjectGroupoid` inspects a finite category with one object
+  whose arrows are all invertible and extracts the corresponding group
+  operations (multiplication, unit, inverses) directly from composition.
+
+These helpers make it easy to shuttle between algebraic data (groups) and
+categorical data (groupoids), and they are exercised by the groupoid test
+suite to ensure the round-trip succeeds for concrete examples.
+
+## Isomorphic Objects
+
+Definition 36 treats an isomorphism `f : C → D` as evidence that the objects `C`
+and `D` are equivalent.  The operations layer records this via a dedicated
+rewrite:
+
+- **MergeObjects** – produced by the `MergeObjectsViaIso` rule, it pairs the
+  forward and backward isomorphisms and instructs the caller to collapse the two
+  objects into a single equivalence class.
+
+Once such a rewrite fires it is natural to maintain a union–find (or similar)
+data structure over objects so that subsequent queries work with canonical
+representatives.  This keeps later rewrites simple: once objects are merged, any
+further diagram manipulation can assume the identification has already been
+performed.

--- a/REWRITER.md
+++ b/REWRITER.md
@@ -1,0 +1,33 @@
+# Operations Rewriter Overview
+
+The operations layer packages a handful of domain-specific simplifications as
+**operation rules**. Each rule inspects a `FiniteCategory` plus a bit of local
+context (a composite path or a focus arrow) and produces a `Suggestion` made of
+concrete `Rewrite` actions. Suggestions are tagged with the oracle that
+justified them and are either `safe` (auto-applied) or `hint` (user approval).
+
+The default rules exported by `operations/rewriter.ts` cover four families of
+reasoning:
+
+1. **Iso cancellation** – detects adjacent inverse arrows in a composite and
+   replaces them with identities.
+2. **Iso upgrades** – promotes arrows to isomorphisms when the user has
+   supplied explicit inverse data. There are two flavours:
+   - `MonoRightInverseUpgrade` handles split monos that already expose a right
+     inverse.
+   - `BalancedMonoEpiUpgrade` runs in categories that advertise
+     `traits.balanced`; it looks for arrows that are both monic and epic,
+     searches for the two-sided inverse guaranteed by balance, and records the
+     corresponding identity rewrites.
+3. **Object and subobject merges** – consumes the witnesses returned by
+   `findMutualMonicFactorizations` and `twoSidedInverses` to merge objects that
+   are known to be isomorphic.
+4. **Extensibility hooks** – the `Rewriter` class is just a registry; new rules
+   can be registered at construction time and are executed in order. This keeps
+   additional techniques (pullback normalisation, Beck–Chevalley rewrites, …)
+   decoupled from the existing rules.
+
+Every rewrite struct records enough information for downstream tooling to apply
+changes or present them interactively. Because we factor all bookkeeping through
+`prettyArrow` and the category interfaces, the same machinery works for the
+finite Set adapters, toy fixtures, and higher-level constructions.

--- a/adapters/iso-ready.ts
+++ b/adapters/iso-ready.ts
@@ -1,0 +1,144 @@
+import type { FinSetCategory, FinSetName, FuncArr } from "../models/finset-cat"
+import { FinSetCat } from "../models/finset-cat"
+import type { FinPosCategory, FinPosObj, MonoMap } from "../models/finpos-cat"
+import { FinPosCat, FinPos } from "../models/finpos-cat"
+import type { FinGrpCategory, FinGrpObj, Hom } from "../models/fingroup-cat"
+import { FinGrpCat, FinGrp } from "../models/fingroup-cat"
+
+type CandidateProvider<Arr> = (arrow: Arr) => Arr[]
+
+const inverseName = (name: unknown): string =>
+  typeof name === "string" && name.length > 0 ? `${name}⁻¹` : "inverse"
+
+export type IsoReadyFinSetCategory = FinSetCategory & {
+  readonly candidatesToInvert: CandidateProvider<FuncArr>
+}
+
+export const makeIsoReadyFinSet = (
+  universe: Record<FinSetName, readonly string[]>,
+): IsoReadyFinSetCategory => {
+  const base = FinSetCat(universe) as IsoReadyFinSetCategory
+  base.candidatesToInvert = (arrow) => {
+    if (!base.isInjective(arrow) || !base.isSurjective(arrow)) return []
+
+    const domain = base.carrier(arrow.dom)
+    const preimage: Record<string, string> = {}
+    for (const element of domain) {
+      const image = arrow.map(element)
+      const previous = preimage[image]
+      if (previous !== undefined && previous !== element) return []
+      preimage[image] = element
+    }
+
+    const codomain = base.carrier(arrow.cod)
+    if (codomain.some((value) => preimage[value] === undefined)) return []
+
+    const candidate: FuncArr = {
+      name: inverseName(arrow.name),
+      dom: arrow.cod,
+      cod: arrow.dom,
+      map: (value: string) => {
+        const mapped = preimage[value]
+        if (mapped === undefined) {
+          throw new Error(`IsoReadyFinSet: missing preimage for ${value}`)
+        }
+        return mapped
+      },
+    }
+
+    return [candidate]
+  }
+  return base
+}
+
+export type IsoReadyFinPosCategory = FinPosCategory & {
+  readonly candidatesToInvert: CandidateProvider<MonoMap>
+}
+
+export const makeIsoReadyFinPos = (
+  objects: readonly FinPosObj[],
+): IsoReadyFinPosCategory => {
+  const base = FinPosCat(objects) as IsoReadyFinPosCategory
+  base.candidatesToInvert = (arrow) => {
+    const dom = base.lookup(arrow.dom)
+    const cod = base.lookup(arrow.cod)
+
+    if (!FinPos.isMonotone(dom, cod, arrow)) return []
+    if (!FinPos.injective(dom, cod, arrow) || !FinPos.surjective(dom, cod, arrow)) return []
+
+    const inverseTable: Record<string, string> = {}
+    for (const element of dom.elems) {
+      const image = arrow.map(element)
+      const previous = inverseTable[image]
+      if (previous !== undefined && previous !== element) return []
+      inverseTable[image] = element
+    }
+
+    if (cod.elems.some((value) => inverseTable[value] === undefined)) return []
+
+    const candidate: MonoMap = {
+      name: inverseName(arrow.name),
+      dom: arrow.cod,
+      cod: arrow.dom,
+      map: (value: string) => {
+        const mapped = inverseTable[value]
+        if (mapped === undefined) {
+          throw new Error(`IsoReadyFinPos: missing preimage for ${value}`)
+        }
+        return mapped
+      },
+    }
+
+    if (!FinPos.isMonotone(cod, dom, candidate)) return []
+
+    return [candidate]
+  }
+  return base
+}
+
+export type IsoReadyFinGrpCategory = FinGrpCategory & {
+  readonly candidatesToInvert: CandidateProvider<Hom>
+}
+
+export const makeIsoReadyFinGrp = (
+  objects: readonly FinGrpObj[],
+): IsoReadyFinGrpCategory => {
+  const base = FinGrpCat(objects) as IsoReadyFinGrpCategory
+  base.candidatesToInvert = (arrow) => {
+    const dom = base.lookup(arrow.dom)
+    const cod = base.lookup(arrow.cod)
+
+    if (!base.isHom(arrow)) return []
+    if (!base.isInjective(arrow) || !base.isSurjective(arrow)) return []
+
+    const inverseTable: Record<string, string> = {}
+    for (const element of dom.elems) {
+      const image = arrow.map(element)
+      const previous = inverseTable[image]
+      if (previous !== undefined && previous !== element) return []
+      inverseTable[image] = element
+    }
+
+    if (cod.elems.some((value) => inverseTable[value] === undefined)) return []
+
+    const candidate: Hom = {
+      name: inverseName(arrow.name),
+      dom: arrow.cod,
+      cod: arrow.dom,
+      map: (value: string) => {
+        const mapped = inverseTable[value]
+        if (mapped === undefined) {
+          throw new Error(`IsoReadyFinGrp: missing preimage for ${value}`)
+        }
+        return mapped
+      },
+    }
+
+    if (!FinGrp.isHom(cod, dom, candidate)) return []
+
+    return [candidate]
+  }
+  return base
+}
+
+export { FinPos, FinGrp }

--- a/allTS.ts
+++ b/allTS.ts
@@ -19036,7 +19036,9 @@ export {
   type CoslicePrecomposition,
 } from "./coslice-precompose"
 export {
+  makeFinitePushoutCalc,
   makeFinitePushoutCalculator,
+  type PushoutCalc,
   type PushoutCalculator,
   type PushoutData,
 } from "./pushout"
@@ -19048,6 +19050,8 @@ export {
 export {
   explainSliceMismatch,
   explainCoSliceMismatch,
+  describeInverseEquation,
+  checkInverseEquation,
 } from "./diagnostics"
 export {
   makeArrowCategory,
@@ -19065,6 +19069,61 @@ export {
   isMono,
   isEpi,
 } from "./kinds/mono-epi"
+export { withMonoEpiCache, type MonoEpiCache } from "./kinds/mono-epi-cache"
+export {
+  identityIsMono,
+  identityIsEpi,
+  composeMonosAreMono,
+  composeEpisAreEpi,
+  rightFactorOfMono,
+  leftFactorOfEpi,
+  saturateMonoEpi,
+  type MonoEpiClosure,
+} from "./kinds/mono-epi-laws"
+export { forkCommutes, isMonoByForks } from "./kinds/fork"
+export {
+  leftInverses,
+  rightInverses,
+  hasLeftInverse,
+  hasRightInverse,
+  twoSidedInverses,
+  isIso as isIsoByInverseSearch,
+} from "./kinds/inverses"
+export { type CatTraits } from "./kinds/traits"
+export { arrowGlyph, prettyArrow } from "./pretty"
+export { isMonoByGlobals, type HasTerminal } from "./traits/global-elements"
+export { nonEpiWitnessInSet, type NonEpiWitness } from "./kinds/epi-witness-set"
+export {
+  FinSetCat,
+  type FinSetName,
+  type FuncArr,
+  type FinSetCategory,
+  isInjective,
+  isSurjective,
+} from "./models/finset-cat"
+export {
+  buildLeftInverseForInjective,
+  buildRightInverseForSurjective,
+} from "./models/finset-inverses"
+export {
+  FinPosCat,
+  FinPos,
+  type FinPosCategory,
+  type FinPosObj,
+  type MonoMap,
+} from "./models/finpos-cat"
+export {
+  FinGrpCat,
+  FinGrp,
+  type FinGrpCategory,
+  type FinGrpObj,
+  type Hom as FinGrpHom,
+} from "./models/fingroup-cat"
+export {
+  kernelElements,
+  nonMonoWitness as finGrpNonMonoWitness,
+  type KernelWitness as FinGrpKernelWitness,
+} from "./models/fingroup-kernel"
 export {
   inverse,
   isIso,
@@ -19073,11 +19132,20 @@ export {
   type IsoWitness,
 } from "./kinds/iso"
 export {
+  findMutualMonicFactorizations,
+  verifyMutualMonicFactorizations,
+  type MutualMonicFactorization,
+  type FactorisationCheckResult,
+} from "./kinds/monic-factorization"
+export {
   epiMonoFactor,
+  epiMonoMiddleIso,
   type Factor as EpiMonoFactor,
+  type FactorIso as EpiMonoFactorIso,
 } from "./kinds/epi-mono-factor"
 export {
   catFromGroup,
+  groupFromOneObjectGroupoid,
   type FinGroup,
 } from "./kinds/group-as-category"
 export {
@@ -19094,13 +19162,44 @@ export {
   type SubcategoryToolkit,
 } from "./textbook-toolkit"
 export {
+  LeftInverseImpliesMono,
+  RightInverseImpliesEpi,
+  IsoIsMonoAndEpi,
+  MonoWithRightInverseIsIso,
+  EpiWithLeftInverseIsIso,
+  type ArrowOracle,
+} from "./oracles/inverses-oracles"
+export {
+  detectBalancedPromotions,
+  type BalancedPromotion,
+} from "./oracles/balanced"
+export {
+  MonicFactorizationYieldsIso,
+  type CategoryOracle,
+} from "./oracles/monic-factorization"
+export {
   checkSliceCategoryLaws,
   type SliceCategoryLawReport,
 } from "./slice-laws"
+export {
+  Rewriter,
+  defaultOperationRules,
+  type OperationRule,
+  type OperationContext,
+  type Suggestion as OperationSuggestion,
+  type Rewrite as OperationRewrite,
+  type NormalizeCompositeRewrite,
+  type UpgradeToIsoRewrite,
+  type ReplaceWithIdentityRewrite,
+  type MergeSubobjectsRewrite,
+  type MergeObjectsRewrite,
+  type FactorThroughEpiMonoRewrite,
+} from "./operations/rewriter"
+export { UnionFind } from "./operations/union-find"
 
 // Namespaces are declared above and exported automatically
 
-export const Chain = { 
+export const Chain = {
   compose: composeChainMap, 
   id: idChainMapField, 
   inclusionIntoCoproduct, 

--- a/coslice-reindexing.ts
+++ b/coslice-reindexing.ts
@@ -1,6 +1,6 @@
 import type { FiniteCategory } from "./finite-cat";
 import type { CosliceArrow, CosliceObject } from "./slice-cat";
-import type { PushoutCalculator } from "./pushout";
+import type { PushoutCalc } from "./pushout";
 
 export interface CosliceReindexingFunctor<Obj, Arr> {
   readonly F0: (object: CosliceObject<Obj, Arr>) => CosliceObject<Obj, Arr>;
@@ -9,7 +9,7 @@ export interface CosliceReindexingFunctor<Obj, Arr> {
 
 export function makeCosliceReindexingFunctor<Obj, Arr>(
   base: FiniteCategory<Obj, Arr>,
-  calculator: PushoutCalculator<Obj, Arr>,
+  calculator: PushoutCalc<Obj, Arr>,
   h: Arr,
   sourceAnchor: Obj,
   targetAnchor: Obj,

--- a/finite-cat.ts
+++ b/finite-cat.ts
@@ -1,10 +1,12 @@
 import type { SimpleCat } from "./simple-cat";
+import type { CatTraits } from "./kinds/traits";
 
 /** A small (finite) category with explicit object and arrow listings. */
 export interface FiniteCategory<Obj, Arr> extends SimpleCat<Obj, Arr> {
   readonly objects: ReadonlyArray<Obj>;
   readonly arrows: ReadonlyArray<Arr>;
   readonly eq: (x: Arr, y: Arr) => boolean;
+  readonly traits?: CatTraits;
 }
 
 /** Utility to deduplicate using a supplied equality predicate. */

--- a/iso/goal-rewriter.ts
+++ b/iso/goal-rewriter.ts
@@ -1,0 +1,52 @@
+import type { FiniteCategory } from "../finite-cat"
+import type { IsoRegistry } from "./registry"
+
+export interface IncomingGoalRewrite<Arr> {
+  readonly predicateOnTarget: (candidate: Arr) => boolean
+  readonly liftOriginal: (arrow: Arr) => Arr
+  readonly lowerToOriginal: (arrow: Arr) => Arr
+}
+
+export interface OutgoingGoalRewrite<Arr> {
+  readonly predicateOnTarget: (candidate: Arr) => boolean
+  readonly liftOriginal: (arrow: Arr) => Arr
+  readonly lowerToOriginal: (arrow: Arr) => Arr
+}
+
+export class GoalRewriter<Obj, Arr> {
+  constructor(
+    private readonly category: FiniteCategory<Obj, Arr>,
+    private readonly registry: IsoRegistry<Obj, Arr>,
+  ) {}
+
+  rewriteIncomingGoal(
+    from: Obj,
+    to: Obj,
+    predicate: (arrow: Arr) => boolean,
+  ): IncomingGoalRewrite<Arr> | null {
+    const witness = this.registry.getWitness(from, to)
+    if (!witness) return null
+
+    return {
+      predicateOnTarget: (candidate) => predicate(this.category.compose(witness.backward, candidate)),
+      liftOriginal: (arrow) => this.category.compose(witness.forward, arrow),
+      lowerToOriginal: (candidate) => this.category.compose(witness.backward, candidate),
+    }
+  }
+
+  rewriteOutgoingGoal(
+    target: Obj,
+    from: Obj,
+    to: Obj,
+    predicate: (arrow: Arr) => boolean,
+  ): OutgoingGoalRewrite<Arr> | null {
+    const witness = this.registry.getWitness(from, to)
+    if (!witness) return null
+
+    return {
+      predicateOnTarget: (candidate) => predicate(this.category.compose(candidate, witness.forward)),
+      liftOriginal: (arrow) => this.category.compose(arrow, witness.backward),
+      lowerToOriginal: (candidate) => this.category.compose(candidate, witness.forward),
+    }
+  }
+}

--- a/iso/homset-linker.ts
+++ b/iso/homset-linker.ts
@@ -1,0 +1,33 @@
+import type { FiniteCategory } from "../finite-cat"
+import type { IsoWitness } from "./types"
+
+export interface HomTransport<Arr> {
+  readonly original: ReadonlyArray<Arr>
+  readonly transported: ReadonlyArray<Arr>
+  readonly roundTrip: ReadonlyArray<Arr>
+}
+
+export class HomSetLinker<Obj, Arr> {
+  constructor(
+    private readonly category: FiniteCategory<Obj, Arr>,
+    private readonly witness: IsoWitness<Arr>,
+  ) {}
+
+  transportInto(source: Obj, left: Obj): HomTransport<Arr> {
+    const originals = this.category.arrows.filter(
+      (arrow) => this.category.src(arrow) === source && this.category.dst(arrow) === left,
+    )
+    const transported = originals.map((arrow) => this.category.compose(this.witness.forward, arrow))
+    const roundTrip = transported.map((arrow) => this.category.compose(this.witness.backward, arrow))
+    return { original: originals, transported, roundTrip }
+  }
+
+  transportOutOf(target: Obj, left: Obj): HomTransport<Arr> {
+    const originals = this.category.arrows.filter(
+      (arrow) => this.category.src(arrow) === left && this.category.dst(arrow) === target,
+    )
+    const transported = originals.map((arrow) => this.category.compose(arrow, this.witness.backward))
+    const roundTrip = transported.map((arrow) => this.category.compose(arrow, this.witness.forward))
+    return { original: originals, transported, roundTrip }
+  }
+}

--- a/iso/registry.ts
+++ b/iso/registry.ts
@@ -1,0 +1,121 @@
+import { UnionFind } from "../operations/union-find"
+import type { FiniteCategory } from "../finite-cat"
+import { HomSetLinker } from "./homset-linker"
+import type { IsoRegistryOptions, IsoWitness } from "./types"
+
+export interface IsoEvent<Obj, Arr> {
+  readonly left: Obj
+  readonly right: Obj
+  readonly witness: IsoWitness<Arr>
+  readonly linker: HomSetLinker<Obj, Arr>
+}
+
+export type IsoListener<Obj, Arr> = (event: IsoEvent<Obj, Arr>) => void
+
+export class IsoRegistry<Obj, Arr> {
+  private readonly unionFind: UnionFind<Obj>
+  private readonly witnesses = new Map<Obj, Map<Obj, IsoWitness<Arr>>>()
+  private readonly listeners: IsoListener<Obj, Arr>[] = []
+
+  constructor(
+    private readonly category: FiniteCategory<Obj, Arr>,
+    private readonly options: IsoRegistryOptions<Obj> = {},
+  ) {
+    const seeds = options.objects ?? category.objects
+    this.unionFind = new UnionFind(seeds)
+  }
+
+  onIsomorphism(listener: IsoListener<Obj, Arr>): void {
+    this.listeners.push(listener)
+  }
+
+  addIsomorphism(left: Obj, right: Obj, witness: IsoWitness<Arr>): void {
+    this.ensureTracked(left)
+    this.ensureTracked(right)
+
+    const { forward, backward } = witness
+    const leftIdentity = this.category.id(left)
+    const rightIdentity = this.category.id(right)
+    const leftComposite = this.category.compose(backward, forward)
+    const rightComposite = this.category.compose(forward, backward)
+
+    const leftOk = this.category.eq(leftComposite, leftIdentity)
+    const rightOk = this.category.eq(rightComposite, rightIdentity)
+
+    if (!leftOk || !rightOk) {
+      const details = [
+        `Invalid isomorphism witness between ${String(left)} and ${String(right)}.`,
+        `Expected backward ∘ forward = id_${String(left)}, got ${describe(leftComposite)}.`,
+        `Expected forward ∘ backward = id_${String(right)}, got ${describe(rightComposite)}.`,
+      ].join(" ")
+      throw new Error(details)
+    }
+
+    this.guardSkeletal(left, right)
+
+    this.storeWitness(left, right, witness)
+    this.storeWitness(right, left, { forward: witness.backward, backward: witness.forward })
+
+    if (!this.options.isSkeletal || Object.is(left, right)) {
+      this.unionFind.union(left, right)
+    }
+
+    const linker = new HomSetLinker(this.category, witness)
+    for (const listener of this.listeners) listener({ left, right, witness, linker })
+  }
+
+  getWitness(left: Obj, right: Obj): IsoWitness<Arr> | null {
+    return this.witnesses.get(left)?.get(right) ?? null
+  }
+
+  representative(object: Obj): Obj {
+    return this.unionFind.find(object)
+  }
+
+  equivalenceRepresentatives(): Map<Obj, Obj> {
+    return this.unionFind.representatives()
+  }
+
+  createHomSetLinker(left: Obj, right: Obj): HomSetLinker<Obj, Arr> | null {
+    const witness = this.getWitness(left, right)
+    if (!witness) return null
+    return new HomSetLinker(this.category, witness)
+  }
+
+  private ensureTracked(object: Obj): void {
+    try {
+      this.unionFind.find(object)
+    } catch {
+      this.unionFind.makeSet(object)
+    }
+  }
+
+  private guardSkeletal(left: Obj, right: Obj): void {
+    if (!this.options.isSkeletal || Object.is(left, right)) return
+
+    const policy = this.options.skeletalPolicy ?? "error"
+    const message = `Skeletal category forbids merging distinct objects: ${String(left)} ≅ ${String(right)}.`
+    this.options.onSkeletalViolation?.({ left, right, message })
+    if (policy === "warn") {
+      console.warn(message)
+      return
+    }
+    if (policy === "ignore") return
+    throw new Error(message)
+  }
+
+  private storeWitness(left: Obj, right: Obj, witness: IsoWitness<Arr>): void {
+    let mapping = this.witnesses.get(left)
+    if (!mapping) {
+      mapping = new Map()
+      this.witnesses.set(left, mapping)
+    }
+    mapping.set(right, witness)
+  }
+}
+
+const describe = (arrow: { id?: string } | null | undefined): string => {
+  if (!arrow) return "<missing>"
+  if (typeof arrow === "object" && typeof arrow.id === "string") return arrow.id
+  return String(arrow)
+}

--- a/iso/types.ts
+++ b/iso/types.ts
@@ -1,0 +1,19 @@
+export type SkeletalPolicy = "error" | "warn" | "ignore"
+
+export interface IsoWitness<Arr> {
+  readonly forward: Arr
+  readonly backward: Arr
+}
+
+export interface SkeletalViolation<Obj> {
+  readonly left: Obj
+  readonly right: Obj
+  readonly message: string
+}
+
+export interface IsoRegistryOptions<Obj> {
+  readonly objects?: Iterable<Obj>
+  readonly isSkeletal?: boolean
+  readonly skeletalPolicy?: SkeletalPolicy
+  readonly onSkeletalViolation?: (info: SkeletalViolation<Obj>) => void
+}

--- a/kinds/epi-mono-factor.ts
+++ b/kinds/epi-mono-factor.ts
@@ -7,10 +7,21 @@ export interface Factor<Obj, Arr> {
   readonly mono: Arr
 }
 
+export interface FactorIso<Arr> {
+  readonly forward: Arr
+  readonly backward: Arr
+}
+
 export const epiMonoFactor = <Obj, Arr>(
   category: FiniteCategory<Obj, Arr>,
   arrow: Arr,
 ): Factor<Obj, Arr> | null => {
+  const specialised = (category as { imageFactorisation?: (arrow: Arr) => Factor<Obj, Arr> | null })
+    .imageFactorisation
+  if (typeof specialised === "function") {
+    const factor = specialised(arrow)
+    if (factor) return factor
+  }
   const source = category.src(arrow)
   const target = category.dst(arrow)
   for (const mid of category.objects) {
@@ -27,5 +38,61 @@ export const epiMonoFactor = <Obj, Arr>(
       }
     }
   }
+  return null
+}
+
+const factorForwardMatches = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  left: Factor<Obj, Arr>,
+  right: Factor<Obj, Arr>,
+  candidate: Arr,
+) => {
+  if (category.src(candidate) !== left.mid) return false
+  if (category.dst(candidate) !== right.mid) return false
+  const throughEpi = category.compose(candidate, left.epi)
+  if (!category.eq(throughEpi, right.epi)) return false
+  const throughMono = category.compose(right.mono, candidate)
+  return category.eq(throughMono, left.mono)
+}
+
+const factorBackwardMatches = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  left: Factor<Obj, Arr>,
+  right: Factor<Obj, Arr>,
+  candidate: Arr,
+) => {
+  if (category.src(candidate) !== right.mid) return false
+  if (category.dst(candidate) !== left.mid) return false
+  const throughEpi = category.compose(candidate, right.epi)
+  if (!category.eq(throughEpi, left.epi)) return false
+  const throughMono = category.compose(left.mono, candidate)
+  return category.eq(throughMono, right.mono)
+}
+
+export const epiMonoMiddleIso = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  left: Factor<Obj, Arr>,
+  right: Factor<Obj, Arr>,
+): FactorIso<Arr> | null => {
+  const forwardCandidates = category.arrows.filter((candidate) =>
+    factorForwardMatches(category, left, right, candidate),
+  )
+  const backwardCandidates = category.arrows.filter((candidate) =>
+    factorBackwardMatches(category, left, right, candidate),
+  )
+
+  const idLeft = category.id(left.mid)
+  const idRight = category.id(right.mid)
+
+  for (const forward of forwardCandidates) {
+    for (const backward of backwardCandidates) {
+      const backThenFor = category.compose(backward, forward)
+      if (!category.eq(backThenFor, idLeft)) continue
+      const forThenBack = category.compose(forward, backward)
+      if (!category.eq(forThenBack, idRight)) continue
+      return { forward, backward }
+    }
+  }
+
   return null
 }

--- a/kinds/epi-witness-set.ts
+++ b/kinds/epi-witness-set.ts
@@ -1,0 +1,70 @@
+import type { FinSetName, FuncArr } from "../models/finset-cat"
+import { isSurjective } from "../models/finset-cat"
+
+export interface NonEpiWitness {
+  readonly missingElement: string
+  readonly codomain: { readonly name: FinSetName; readonly elems: readonly string[] }
+  readonly g: FuncArr
+  readonly h: FuncArr
+}
+
+const requireCarrier = (
+  universe: Record<FinSetName, readonly string[]>,
+  name: FinSetName,
+): readonly string[] => {
+  const carrier = universe[name]
+  if (!carrier) {
+    throw new Error(`FinSet non-epi witness: unknown carrier ${name}`)
+  }
+  return carrier
+}
+
+const imageOf = (
+  universe: Record<FinSetName, readonly string[]>,
+  arrow: FuncArr,
+): Set<string> => {
+  const elems = requireCarrier(universe, arrow.dom)
+  const hits = new Set<string>()
+  for (const element of elems) {
+    hits.add(arrow.map(element))
+  }
+  return hits
+}
+
+const makeWitnessCodomainName = (arrow: FuncArr): FinSetName => `${arrow.cod}__epiWitness_${arrow.name}`
+
+export function nonEpiWitnessInSet(
+  universe: Record<FinSetName, readonly string[]>,
+  arrow: FuncArr,
+): NonEpiWitness | null {
+  if (isSurjective(universe, arrow)) return null
+
+  const codomainCarrier = requireCarrier(universe, arrow.cod)
+  const image = imageOf(universe, arrow)
+  const missing = codomainCarrier.find((element) => !image.has(element))
+  if (!missing) return null
+
+  const witnessCodomainName = makeWitnessCodomainName(arrow)
+  const witnessCodomain = { name: witnessCodomainName, elems: ["0", "1"] as const }
+
+  const g: FuncArr = {
+    name: `const_${arrow.name}`,
+    dom: arrow.cod,
+    cod: witnessCodomainName,
+    map: () => "0",
+  }
+
+  const h: FuncArr = {
+    name: `mask_${arrow.name}`,
+    dom: arrow.cod,
+    cod: witnessCodomainName,
+    map: (d) => (image.has(d) ? "0" : "1"),
+  }
+
+  return {
+    missingElement: missing,
+    codomain: witnessCodomain,
+    g,
+    h,
+  }
+}

--- a/kinds/fork.ts
+++ b/kinds/fork.ts
@@ -1,0 +1,44 @@
+import type { FiniteCategory } from "../finite-cat"
+
+/**
+ * Check whether two arrows form a commuting fork over a given arrow.
+ *
+ * A fork over f is a pair of arrows g, h with shared domain X and codomain
+ * matching the domain of f such that f ∘ g = f ∘ h.
+ */
+export const forkCommutes = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  f: Arr,
+  g: Arr,
+  h: Arr,
+): boolean => {
+  if (category.src(f) !== category.dst(g)) return false
+  if (category.src(f) !== category.dst(h)) return false
+  if (category.src(g) !== category.src(h)) return false
+  const fg = category.compose(f, g)
+  const fh = category.compose(f, h)
+  return category.eq(fg, fh)
+}
+
+/**
+ * Determine monicity by inspecting all forks over the arrow and ensuring any
+ * commuting fork has identical legs. An optional callback reports the first
+ * counterexample discovered.
+ */
+export const isMonoByForks = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  f: Arr,
+  onCounterexample?: (g: Arr, h: Arr) => void,
+): boolean => {
+  const domain = category.src(f)
+  const candidates = category.arrows.filter((arrow) => category.dst(arrow) === domain)
+  for (const g of candidates) {
+    for (const h of candidates) {
+      if (!forkCommutes(category, f, g, h)) continue
+      if (category.eq(g, h)) continue
+      onCounterexample?.(g, h)
+      return false
+    }
+  }
+  return true
+}

--- a/kinds/group-as-category.ts
+++ b/kinds/group-as-category.ts
@@ -1,35 +1,37 @@
 import type { FiniteCategory } from "../finite-cat"
 
-export interface FinGroup {
-  readonly elements: ReadonlyArray<string>
-  readonly multiply: (a: string, b: string) => string
-  readonly inverse: (a: string) => string
-  readonly unit: string
+export interface FinGroup<Element = string> {
+  readonly elements: ReadonlyArray<Element>
+  readonly multiply: (a: Element, b: Element) => Element
+  readonly inverse: (a: Element) => Element
+  readonly unit: Element
 }
 
 interface GroupObject {
   readonly name: "*"
 }
 
-interface GroupArrow {
+interface GroupArrow<Element> {
   readonly name: string
-  readonly element: string
+  readonly element: Element
   readonly source: GroupObject
   readonly target: GroupObject
 }
 
 const star: GroupObject = { name: "*" }
 
-export const catFromGroup = (group: FinGroup): FiniteCategory<GroupObject, GroupArrow> => {
-  const arrows: GroupArrow[] = group.elements.map((element) => ({
-    name: element,
+export const catFromGroup = <Element>(
+  group: FinGroup<Element>,
+): FiniteCategory<GroupObject, GroupArrow<Element>> => {
+  const arrows: Array<GroupArrow<Element>> = group.elements.map((element) => ({
+    name: String(element),
     element,
     source: star,
     target: star,
   }))
   const index = new Map(group.elements.map((element, i) => [element, i]))
 
-  const id = (_: GroupObject): GroupArrow => {
+  const id = (_: GroupObject): GroupArrow<Element> => {
     const idx = index.get(group.unit)
     if (idx == null) {
       throw new Error("Group unit not present in element list")
@@ -41,7 +43,7 @@ export const catFromGroup = (group: FinGroup): FiniteCategory<GroupObject, Group
     return arrow
   }
 
-  const compose = (g: GroupArrow, f: GroupArrow): GroupArrow => {
+  const compose = (g: GroupArrow<Element>, f: GroupArrow<Element>): GroupArrow<Element> => {
     const product = group.multiply(f.element, g.element)
     const idx = index.get(product)
     if (idx == null) {
@@ -54,7 +56,7 @@ export const catFromGroup = (group: FinGroup): FiniteCategory<GroupObject, Group
     return arrow
   }
 
-  const eq = (a: GroupArrow, b: GroupArrow): boolean => a.element === b.element
+  const eq = (a: GroupArrow<Element>, b: GroupArrow<Element>): boolean => a.element === b.element
 
   return {
     objects: [star],
@@ -64,5 +66,59 @@ export const catFromGroup = (group: FinGroup): FiniteCategory<GroupObject, Group
     src: (arrow) => arrow.source,
     dst: (arrow) => arrow.target,
     eq,
+  }
+}
+
+const canonicalArrow = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  pool: ReadonlyArray<Arr>,
+  candidate: Arr,
+): Arr => {
+  for (const arrow of pool) {
+    if (category.eq(arrow, candidate)) return arrow
+  }
+  throw new Error("Composite arrow not present in one-object groupoid")
+}
+
+export const groupFromOneObjectGroupoid = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+): { readonly object: Obj; readonly group: FinGroup<Arr> } => {
+  if (category.objects.length !== 1) {
+    throw new Error("Expected a single-object category to recover a group")
+  }
+
+  const object = category.objects[0]!
+  const loops = category.arrows.filter(
+    (arrow) => category.src(arrow) === object && category.dst(arrow) === object,
+  )
+
+  if (loops.length !== category.arrows.length) {
+    throw new Error("Category contains arrows between distinct objects")
+  }
+
+  const unit = canonicalArrow(category, loops, category.id(object))
+
+  const multiply = (a: Arr, b: Arr): Arr =>
+    canonicalArrow(category, loops, category.compose(b, a))
+
+  const inverse = (a: Arr): Arr => {
+    for (const candidate of loops) {
+      const left = category.compose(candidate, a)
+      const right = category.compose(a, candidate)
+      if (category.eq(left, unit) && category.eq(right, unit)) {
+        return candidate
+      }
+    }
+    throw new Error("Arrow in one-object groupoid lacks an inverse")
+  }
+
+  return {
+    object,
+    group: {
+      elements: loops,
+      unit,
+      multiply,
+      inverse,
+    },
   }
 }

--- a/kinds/groupoid.ts
+++ b/kinds/groupoid.ts
@@ -1,9 +1,9 @@
 import type { FiniteCategory } from "../finite-cat"
 import type { FinGroup } from "./group-as-category"
 
-interface ActionArrow {
+interface ActionArrow<Element> {
   readonly name: string
-  readonly element: string
+  readonly element: Element
   readonly source: string
   readonly target: string
 }
@@ -27,50 +27,52 @@ export const isGroupoid = <Obj, Arr>(category: FiniteCategory<Obj, Arr>): boolea
   return true
 }
 
-export const actionGroupoid = (
-  group: FinGroup,
+export const actionGroupoid = <Element>(
+  group: FinGroup<Element>,
   objects: ReadonlyArray<string>,
-  act: (element: string, object: string) => string,
-): FiniteCategory<string, ActionArrow> => {
+  act: (element: Element, object: string) => string,
+): FiniteCategory<string, ActionArrow<Element>> => {
   const uniqueObjects = [...new Set(objects)]
-  const arrows: ActionArrow[] = []
-  const lookup = new Map<string, ActionArrow>()
+  const arrows: Array<ActionArrow<Element>> = []
+  const lookup = new Map<string, ActionArrow<Element>>()
+
+  const keyFor = (object: string, element: Element): string => `${object}|${String(element)}`
 
   for (const object of uniqueObjects) {
     for (const element of group.elements) {
       const target = act(element, object)
-      const arrow: ActionArrow = {
-        name: `${element}:${object}`,
+      const arrow: ActionArrow<Element> = {
+        name: `${String(element)}:${object}`,
         element,
         source: object,
         target,
       }
       arrows.push(arrow)
-      lookup.set(`${object}|${element}`, arrow)
+      lookup.set(keyFor(object, element), arrow)
     }
   }
 
-  const id = (object: string): ActionArrow => {
-    const arrow = lookup.get(`${object}|${group.unit}`)
+  const id = (object: string): ActionArrow<Element> => {
+    const arrow = lookup.get(keyFor(object, group.unit))
     if (!arrow) {
       throw new Error(`Identity arrow for ${object} not found`)
     }
     return arrow
   }
 
-  const compose = (g: ActionArrow, f: ActionArrow): ActionArrow => {
+  const compose = (g: ActionArrow<Element>, f: ActionArrow<Element>): ActionArrow<Element> => {
     if (f.target !== g.source) {
       throw new Error("actionGroupoid: domain mismatch")
     }
     const compositeElement = group.multiply(f.element, g.element)
-    const arrow = lookup.get(`${f.source}|${compositeElement}`)
+    const arrow = lookup.get(keyFor(f.source, compositeElement))
     if (!arrow) {
       throw new Error(`Missing arrow for element ${compositeElement} at ${f.source}`)
     }
     return arrow
   }
 
-  const eq = (a: ActionArrow, b: ActionArrow): boolean =>
+  const eq = (a: ActionArrow<Element>, b: ActionArrow<Element>): boolean =>
     a.source === b.source && a.element === b.element && a.target === b.target
 
   return {

--- a/kinds/idempotent.ts
+++ b/kinds/idempotent.ts
@@ -1,0 +1,12 @@
+import type { FiniteCategory } from "../finite-cat"
+
+export const isIdempotent = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => category.eq(category.compose(arrow, arrow), arrow)
+
+export const projectorFromSection = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  section: Arr,
+  retraction: Arr,
+): Arr => category.compose(section, retraction)

--- a/kinds/inverses.ts
+++ b/kinds/inverses.ts
@@ -1,0 +1,114 @@
+import type { FiniteCategory } from "../finite-cat"
+import { pushUnique } from "../finite-cat"
+
+type InverseAwareCategory<Obj, Arr> = FiniteCategory<Obj, Arr> & {
+  readonly splitMonoWitness?: (arrow: Arr) => Arr
+  readonly splitEpiWitness?: (arrow: Arr) => Arr
+  readonly candidatesToInvert?: (arrow: Arr) => readonly Arr[]
+}
+
+const collectCandidates = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+  predicate: (candidate: Arr) => boolean,
+): Arr[] => {
+  const matches: Arr[] = []
+  for (const candidate of category.arrows) {
+    if (predicate(candidate)) matches.push(candidate)
+  }
+  return matches
+}
+
+export const rightInverses = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): Arr[] => {
+  const target = category.dst(arrow)
+  const source = category.src(arrow)
+  const identity = category.id(target)
+  const matches = collectCandidates(category, arrow, (candidate) => {
+    if (category.src(candidate) !== target) return false
+    if (category.dst(candidate) !== source) return false
+    const composite = category.compose(arrow, candidate)
+    return category.eq(composite, identity)
+  })
+  const enriched = category as InverseAwareCategory<Obj, Arr>
+  const candidateList = enriched.candidatesToInvert?.(arrow) ?? []
+  for (const candidate of candidateList) {
+    if (category.src(candidate) !== target) continue
+    if (category.dst(candidate) !== source) continue
+    const composite = category.compose(arrow, candidate)
+    if (category.eq(composite, identity)) {
+      pushUnique(matches, candidate, category.eq)
+    }
+  }
+  if (enriched.splitEpiWitness) {
+    try {
+      const witness = enriched.splitEpiWitness(arrow)
+      pushUnique(matches, witness, category.eq)
+    } catch (error) {
+      // ignore categories that decline to provide a witness
+    }
+  }
+  return matches
+}
+
+export const leftInverses = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): Arr[] => {
+  const target = category.dst(arrow)
+  const source = category.src(arrow)
+  const identity = category.id(source)
+  const matches = collectCandidates(category, arrow, (candidate) => {
+    if (category.src(candidate) !== target) return false
+    if (category.dst(candidate) !== source) return false
+    const composite = category.compose(candidate, arrow)
+    return category.eq(composite, identity)
+  })
+  const enriched = category as InverseAwareCategory<Obj, Arr>
+  const candidateList = enriched.candidatesToInvert?.(arrow) ?? []
+  for (const candidate of candidateList) {
+    if (category.src(candidate) !== target) continue
+    if (category.dst(candidate) !== source) continue
+    const composite = category.compose(candidate, arrow)
+    if (category.eq(composite, identity)) {
+      pushUnique(matches, candidate, category.eq)
+    }
+  }
+  if (enriched.splitMonoWitness) {
+    try {
+      const witness = enriched.splitMonoWitness(arrow)
+      pushUnique(matches, witness, category.eq)
+    } catch (error) {
+      // category could not provide a split mono witness; ignore
+    }
+  }
+  return matches
+}
+
+export const hasRightInverse = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => rightInverses(category, arrow).length > 0
+
+export const hasLeftInverse = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => leftInverses(category, arrow).length > 0
+
+export const twoSidedInverses = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): Arr[] => {
+  const lefts = leftInverses(category, arrow)
+  if (lefts.length === 0) return []
+  const rights = rightInverses(category, arrow)
+  if (rights.length === 0) return []
+  return lefts.filter((candidate) => rights.some((right) => category.eq(candidate, right)))
+}
+
+export const isIso = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => twoSidedInverses(category, arrow).length > 0

--- a/kinds/iso.ts
+++ b/kinds/iso.ts
@@ -1,4 +1,7 @@
 import type { FiniteCategory } from "../finite-cat"
+import { twoSidedInverses } from "./inverses"
+
+export { isIso } from "./inverses"
 
 export interface IsoWitness<Arr> {
   readonly forward: Arr
@@ -9,23 +12,9 @@ export const inverse = <Obj, Arr>(
   category: FiniteCategory<Obj, Arr>,
   arrow: Arr,
 ): Arr | null => {
-  const source = category.src(arrow)
-  const target = category.dst(arrow)
-  for (const candidate of category.arrows) {
-    if (category.src(candidate) !== target || category.dst(candidate) !== source) continue
-    const left = category.compose(candidate, arrow)
-    const right = category.compose(arrow, candidate)
-    if (category.eq(left, category.id(source)) && category.eq(right, category.id(target))) {
-      return candidate
-    }
-  }
-  return null
+  const [candidate] = twoSidedInverses(category, arrow)
+  return candidate ?? null
 }
-
-export const isIso = <Obj, Arr>(
-  category: FiniteCategory<Obj, Arr>,
-  arrow: Arr,
-): boolean => inverse(category, arrow) !== null
 
 export const isoWitness = <Obj, Arr>(
   category: FiniteCategory<Obj, Arr>,

--- a/kinds/monic-factorization.ts
+++ b/kinds/monic-factorization.ts
@@ -1,0 +1,100 @@
+import type { FiniteCategory } from "../finite-cat"
+import { isMono } from "./mono-epi"
+
+export interface MutualMonicFactorization<Arr> {
+  readonly left: Arr
+  readonly right: Arr
+  readonly forward: Arr
+  readonly backward: Arr
+}
+
+const arrowKey = <Arr>(lookup: Map<Arr, number>, arrow: Arr): string => {
+  const index = lookup.get(arrow)
+  if (index === undefined) {
+    throw new Error("monic factorisation: arrow not present in category.arrows")
+  }
+  return String(index)
+}
+
+export const findMutualMonicFactorizations = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+): MutualMonicFactorization<Arr>[] => {
+  const results: MutualMonicFactorization<Arr>[] = []
+  const index = new Map<Arr, number>()
+  category.arrows.forEach((arrow, i) => index.set(arrow, i))
+  const seen = new Set<string>()
+
+  for (const r of category.arrows) {
+    if (!isMono(category, r)) continue
+    const cod = category.dst(r)
+    const domR = category.src(r)
+
+    for (const s of category.arrows) {
+      if (!isMono(category, s)) continue
+      if (category.dst(s) !== cod) continue
+      const domS = category.src(s)
+
+      const key = `${arrowKey(index, r)}|${arrowKey(index, s)}`
+      if (seen.has(key)) continue
+
+      const gCandidates = category.arrows.filter(
+        (candidate) => category.src(candidate) === domR && category.dst(candidate) === domS,
+      )
+      const hCandidates = category.arrows.filter(
+        (candidate) => category.src(candidate) === domS && category.dst(candidate) === domR,
+      )
+
+      let recorded = false
+      for (const g of gCandidates) {
+        const sg = category.compose(s, g)
+        if (!category.eq(sg, r)) continue
+        for (const h of hCandidates) {
+          const rh = category.compose(r, h)
+          if (!category.eq(rh, s)) continue
+          results.push({ left: r, right: s, forward: g, backward: h })
+          recorded = true
+          break
+        }
+        if (recorded) break
+      }
+
+      if (recorded) {
+        seen.add(key)
+        seen.add(`${arrowKey(index, s)}|${arrowKey(index, r)}`)
+      }
+    }
+  }
+
+  return results
+}
+
+export interface FactorisationCheckResult<Arr> {
+  readonly holds: boolean
+  readonly witness?: MutualMonicFactorization<Arr>
+  readonly detail?: string
+}
+
+export const verifyMutualMonicFactorizations = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+): FactorisationCheckResult<Arr> => {
+  for (const witness of findMutualMonicFactorizations(category)) {
+    const domR = category.src(witness.left)
+    const domS = category.src(witness.right)
+    const hg = category.compose(witness.backward, witness.forward)
+    const gh = category.compose(witness.forward, witness.backward)
+    const idR = category.id(domR)
+    const idS = category.id(domS)
+    const leftOk = category.eq(hg, idR)
+    const rightOk = category.eq(gh, idS)
+    if (!leftOk || !rightOk) {
+      const detail = [
+        leftOk ? undefined : "h ∘ g ≠ 1",
+        rightOk ? undefined : "g ∘ h ≠ 1",
+      ]
+        .filter((entry): entry is string => entry !== undefined)
+        .join(", ")
+      return { holds: false, witness, detail }
+    }
+  }
+  return { holds: true }
+}

--- a/kinds/mono-epi-cache.ts
+++ b/kinds/mono-epi-cache.ts
@@ -1,0 +1,35 @@
+import type { FiniteCategory } from "../finite-cat";
+import { isMono as computeMono, isEpi as computeEpi } from "./mono-epi";
+
+export interface MonoEpiCache<Obj, Arr> {
+  readonly isMono: (f: Arr) => boolean;
+  readonly isEpi: (f: Arr) => boolean;
+  clear(): void;
+}
+
+export function withMonoEpiCache<Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+): MonoEpiCache<Obj, Arr> {
+  const mono = new Map<Arr, boolean>();
+  const epi = new Map<Arr, boolean>();
+
+  const memoise = (store: Map<Arr, boolean>, arrow: Arr, calc: () => boolean): boolean => {
+    const cached = store.get(arrow);
+    if (cached !== undefined) return cached;
+    const value = calc();
+    store.set(arrow, value);
+    return value;
+  };
+
+  const isMono = (f: Arr): boolean => memoise(mono, f, () => computeMono(category, f));
+  const isEpi = (f: Arr): boolean => memoise(epi, f, () => computeEpi(category, f));
+
+  return {
+    isMono,
+    isEpi,
+    clear() {
+      mono.clear();
+      epi.clear();
+    },
+  };
+}

--- a/kinds/mono-epi-laws.ts
+++ b/kinds/mono-epi-laws.ts
@@ -1,0 +1,171 @@
+import type { FiniteCategory } from "../finite-cat"
+import { isMono, isEpi } from "./mono-epi"
+import { withMonoEpiCache } from "./mono-epi-cache"
+
+export const identityIsMono = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  object: Obj,
+): boolean => isMono(category, category.id(object))
+
+export const identityIsEpi = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  object: Obj,
+): boolean => isEpi(category, category.id(object))
+
+export const composeMonosAreMono = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  g: Arr,
+  f: Arr,
+): boolean => {
+  if (category.src(g) !== category.dst(f)) {
+    throw new Error("composeMonosAreMono: arrows must be composable")
+  }
+  if (!isMono(category, f) || !isMono(category, g)) return true
+  const composite = category.compose(g, f)
+  return isMono(category, composite)
+}
+
+export const composeEpisAreEpi = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  g: Arr,
+  f: Arr,
+): boolean => {
+  if (category.src(g) !== category.dst(f)) {
+    throw new Error("composeEpisAreEpi: arrows must be composable")
+  }
+  if (!isEpi(category, f) || !isEpi(category, g)) return true
+  const composite = category.compose(g, f)
+  return isEpi(category, composite)
+}
+
+export const rightFactorOfMono = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  g: Arr,
+  f: Arr,
+): boolean => {
+  if (category.src(g) !== category.dst(f)) {
+    throw new Error("rightFactorOfMono: arrows must be composable")
+  }
+  const composite = category.compose(g, f)
+  if (!isMono(category, composite)) return true
+  return isMono(category, f)
+}
+
+export const leftFactorOfEpi = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  g: Arr,
+  f: Arr,
+): boolean => {
+  if (category.src(g) !== category.dst(f)) {
+    throw new Error("leftFactorOfEpi: arrows must be composable")
+  }
+  const composite = category.compose(g, f)
+  if (!isEpi(category, composite)) return true
+  return isEpi(category, g)
+}
+
+export interface MonoEpiClosure<Obj, Arr> {
+  readonly idMonos: ReadonlySet<Obj>
+  readonly idEpis: ReadonlySet<Obj>
+  readonly monos: ReadonlySet<Arr>
+  readonly epis: ReadonlySet<Arr>
+}
+
+export const saturateMonoEpi = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+): MonoEpiClosure<Obj, Arr> => {
+  const cache = withMonoEpiCache(category)
+  const idMonos = new Set<Obj>()
+  const idEpis = new Set<Obj>()
+  const monos = new Set<Arr>()
+  const epis = new Set<Arr>()
+
+  const canonical = (arrow: Arr): Arr | undefined =>
+    category.arrows.find((candidate) => category.eq(candidate, arrow))
+
+  const ensureMono = (arrow: Arr): boolean => {
+    const canon = canonical(arrow)
+    if (!canon) return false
+    if (monos.has(canon)) return false
+    if (!cache.isMono(canon)) return false
+    monos.add(canon)
+    return true
+  }
+
+  const ensureEpi = (arrow: Arr): boolean => {
+    const canon = canonical(arrow)
+    if (!canon) return false
+    if (epis.has(canon)) return false
+    if (!cache.isEpi(canon)) return false
+    epis.add(canon)
+    return true
+  }
+
+  const ensureIdentityMono = (object: Obj): boolean => {
+    if (idMonos.has(object)) return false
+    const identity = category.id(object)
+    const canonicalId = canonical(identity)
+    const holds = canonicalId ? cache.isMono(canonicalId) : isMono(category, identity)
+    if (!holds) return false
+    idMonos.add(object)
+    if (canonicalId) monos.add(canonicalId)
+    return true
+  }
+
+  const ensureIdentityEpi = (object: Obj): boolean => {
+    if (idEpis.has(object)) return false
+    const identity = category.id(object)
+    const canonicalId = canonical(identity)
+    const holds = canonicalId ? cache.isEpi(canonicalId) : isEpi(category, identity)
+    if (!holds) return false
+    idEpis.add(object)
+    if (canonicalId) epis.add(canonicalId)
+    return true
+  }
+
+  let changed = true
+  while (changed) {
+    changed = false
+
+    for (const object of category.objects) {
+      if (ensureIdentityMono(object)) changed = true
+      if (ensureIdentityEpi(object)) changed = true
+    }
+
+    for (const arrow of category.arrows) {
+      if (ensureMono(arrow)) changed = true
+      if (ensureEpi(arrow)) changed = true
+    }
+
+    for (const g of category.arrows) {
+      for (const f of category.arrows) {
+        if (category.src(g) !== category.dst(f)) continue
+
+        const canonF = canonical(f)
+        const canonG = canonical(g)
+        const composite = category.compose(g, f)
+
+        if (canonF && canonG && monos.has(canonF) && monos.has(canonG)) {
+          if (ensureMono(composite)) changed = true
+        }
+        if (canonF && cache.isMono(composite)) {
+          if (ensureMono(canonF)) changed = true
+        }
+
+        if (canonF && canonG && epis.has(canonF) && epis.has(canonG)) {
+          if (ensureEpi(composite)) changed = true
+        }
+        if (canonG && cache.isEpi(composite)) {
+          if (ensureEpi(canonG)) changed = true
+        }
+      }
+    }
+  }
+
+  return {
+    idMonos,
+    idEpis,
+    monos,
+    epis,
+  }
+}

--- a/kinds/mono-epi.ts
+++ b/kinds/mono-epi.ts
@@ -1,4 +1,11 @@
 import type { FiniteCategory } from "../finite-cat"
+import type { CatTraits } from "./traits"
+
+type FunctionalCategory<Obj, Arr> = FiniteCategory<Obj, Arr> & {
+  readonly traits?: CatTraits
+  readonly isInjective?: (arrow: Arr) => boolean
+  readonly isSurjective?: (arrow: Arr) => boolean
+}
 
 /**
  * Determine whether an arrow is a monomorphism by checking left cancellability
@@ -8,6 +15,10 @@ export const isMono = <Obj, Arr>(
   category: FiniteCategory<Obj, Arr>,
   arrow: Arr,
 ): boolean => {
+  const maybeFunctional = category as FunctionalCategory<Obj, Arr>
+  if (maybeFunctional.traits?.functionalArrows && maybeFunctional.isInjective) {
+    return maybeFunctional.isInjective(arrow)
+  }
   const target = category.src(arrow)
   const candidates = category.arrows.filter((a) => category.dst(a) === target)
   for (const u of candidates) {
@@ -30,6 +41,10 @@ export const isEpi = <Obj, Arr>(
   category: FiniteCategory<Obj, Arr>,
   arrow: Arr,
 ): boolean => {
+  const maybeFunctional = category as FunctionalCategory<Obj, Arr>
+  if (maybeFunctional.traits?.functionalArrows && maybeFunctional.isSurjective) {
+    return maybeFunctional.isSurjective(arrow)
+  }
   const source = category.dst(arrow)
   const candidates = category.arrows.filter((a) => category.src(a) === source)
   for (const u of candidates) {

--- a/kinds/splits.ts
+++ b/kinds/splits.ts
@@ -1,0 +1,24 @@
+import type { FiniteCategory } from "../finite-cat"
+import { hasLeftInverse, hasRightInverse } from "./inverses"
+
+export const isRetractionOf = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  retraction: Arr,
+  section: Arr,
+): boolean => category.eq(category.compose(retraction, section), category.id(category.src(section)))
+
+export const isSectionOf = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  section: Arr,
+  retraction: Arr,
+): boolean => isRetractionOf(category, retraction, section)
+
+export const isSplitMono = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => hasLeftInverse(category, arrow)
+
+export const isSplitEpi = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): boolean => hasRightInverse(category, arrow)

--- a/kinds/traits.ts
+++ b/kinds/traits.ts
@@ -1,0 +1,5 @@
+/** Optional metadata advertised by concrete category adapters. */
+export interface CatTraits {
+  readonly functionalArrows?: boolean
+  readonly balanced?: boolean
+}

--- a/models/fingroup-cat.ts
+++ b/models/fingroup-cat.ts
@@ -1,0 +1,121 @@
+import type { FiniteCategory } from "../finite-cat"
+
+export interface FinGrpObj {
+  readonly name: string
+  readonly elems: readonly string[]
+  readonly mul: (a: string, b: string) => string
+  readonly e: string
+  readonly inv: (a: string) => string
+}
+
+export interface Hom {
+  readonly name: string
+  readonly dom: string
+  readonly cod: string
+  readonly map: (x: string) => string
+}
+
+export interface FinGrpCategory extends FiniteCategory<string, Hom> {
+  readonly traits: { readonly functionalArrows: true; readonly balanced: true }
+  readonly isHom: (arrow: Hom) => boolean
+  readonly isInjective: (arrow: Hom) => boolean
+  readonly isSurjective: (arrow: Hom) => boolean
+  readonly lookup: (name: string) => FinGrpObj
+}
+
+function ensureObject(index: Record<string, FinGrpObj>, name: string): FinGrpObj {
+  const obj = index[name]
+  if (!obj) {
+    throw new Error(`FinGrpCat: unknown object ${name}`)
+  }
+  return obj
+}
+
+export function FinGrpCat(objects: readonly FinGrpObj[]): FinGrpCategory {
+  const byName: Record<string, FinGrpObj> = {}
+  for (const obj of objects) {
+    byName[obj.name] = obj
+  }
+
+  const objectList = Object.keys(byName)
+  const arrows: Hom[] = []
+
+  const eq = (f: Hom, g: Hom) =>
+    f.dom === g.dom &&
+    f.cod === g.cod &&
+    ensureObject(byName, f.dom).elems.every((x) => f.map(x) === g.map(x))
+
+  const id = (G: string): Hom => ({
+    name: `id_${G}`,
+    dom: G,
+    cod: G,
+    map: (x) => x,
+  })
+
+  const compose = (g: Hom, f: Hom): Hom => {
+    if (f.cod !== g.dom) {
+      throw new Error("FinGrpCat: compose expects matching codomain/domain")
+    }
+    return {
+      name: `${g.name}∘${f.name}`,
+      dom: f.dom,
+      cod: g.cod,
+      map: (x) => g.map(f.map(x)),
+    }
+  }
+
+  const src = (f: Hom) => f.dom
+  const dst = (f: Hom) => f.cod
+
+  const category: FinGrpCategory = {
+    objects: objectList,
+    arrows,
+    id,
+    compose,
+    src,
+    dst,
+    eq,
+    traits: { functionalArrows: true, balanced: true },
+    isHom: (arrow) => FinGrp.isHom(ensureObject(byName, arrow.dom), ensureObject(byName, arrow.cod), arrow),
+    isInjective: (arrow) => FinGrp.injective(ensureObject(byName, arrow.dom), ensureObject(byName, arrow.cod), arrow),
+    isSurjective: (arrow) => FinGrp.surjective(ensureObject(byName, arrow.dom), ensureObject(byName, arrow.cod), arrow),
+    lookup: (name) => ensureObject(byName, name),
+  }
+
+  return category
+}
+
+export const FinGrp = {
+  isHom(dom: FinGrpObj, cod: FinGrpObj, f: Hom): boolean {
+    if (f.map(dom.e) !== cod.e) return false
+    for (const a of dom.elems) {
+      for (const b of dom.elems) {
+        const left = f.map(dom.mul(a, b))
+        const right = cod.mul(f.map(a), f.map(b))
+        if (left !== right) {
+          return false
+        }
+      }
+    }
+    return true
+  },
+  injective(dom: FinGrpObj, _cod: FinGrpObj, f: Hom): boolean {
+    const seen = new Map<string, string>()
+    for (const a of dom.elems) {
+      const image = f.map(a)
+      const previous = seen.get(image)
+      if (previous && previous !== a) {
+        return false
+      }
+      seen.set(image, a)
+    }
+    return true
+  },
+  surjective(_dom: FinGrpObj, cod: FinGrpObj, f: Hom): boolean {
+    const pending = new Set(cod.elems)
+    for (const a of _dom.elems) {
+      pending.delete(f.map(a))
+    }
+    return pending.size === 0
+  },
+}

--- a/models/fingroup-kernel.ts
+++ b/models/fingroup-kernel.ts
@@ -1,0 +1,69 @@
+import type { FinGrpObj, Hom } from "./fingroup-cat"
+
+export function kernelElements(domain: FinGrpObj, codomain: FinGrpObj, f: Hom): string[] {
+  if (f.dom !== domain.name) {
+    throw new Error(`kernelElements: expected domain ${domain.name} for ${f.name}`)
+  }
+  if (f.cod !== codomain.name) {
+    throw new Error(`kernelElements: expected codomain ${codomain.name} for ${f.name}`)
+  }
+  const ker: string[] = []
+  for (const x of domain.elems) {
+    if (f.map(x) === codomain.e) {
+      ker.push(x)
+    }
+  }
+  return ker
+}
+
+export function isInjectiveHom(domain: FinGrpObj, codomain: FinGrpObj, f: Hom): boolean {
+  const seen = new Map<string, string>()
+  for (const a of domain.elems) {
+    const image = f.map(a)
+    const prev = seen.get(image)
+    if (prev && prev !== a) {
+      return false
+    }
+    seen.set(image, a)
+  }
+  return true
+}
+
+export interface KernelWitness {
+  readonly subgroup: FinGrpObj
+  readonly inclusion: Hom
+  readonly collapse: Hom
+}
+
+export function nonMonoWitness(
+  domain: FinGrpObj,
+  codomain: FinGrpObj,
+  f: Hom,
+  options?: { readonly kernelName?: string }
+): KernelWitness | null {
+  const kerElems = kernelElements(domain, codomain, f)
+  if (kerElems.length <= 1) {
+    return null
+  }
+  const kernelName = options?.kernelName ?? `Ker(${f.name})`
+  const subgroup: FinGrpObj = {
+    name: kernelName,
+    elems: kerElems,
+    mul: (a, b) => domain.mul(a, b),
+    e: domain.e,
+    inv: (a) => domain.inv(a),
+  }
+  const inclusion: Hom = {
+    name: `ι_${kernelName}`,
+    dom: kernelName,
+    cod: domain.name,
+    map: (x) => x,
+  }
+  const collapse: Hom = {
+    name: `const_${domain.e}`,
+    dom: kernelName,
+    cod: domain.name,
+    map: (_x: string) => domain.e,
+  }
+  return { subgroup, inclusion, collapse }
+}

--- a/models/finpos-cat.ts
+++ b/models/finpos-cat.ts
@@ -1,0 +1,144 @@
+import type { FiniteCategory } from "../finite-cat"
+
+export interface FinPosObj {
+  readonly name: string
+  readonly elems: readonly string[]
+  readonly leq: (a: string, b: string) => boolean
+}
+
+export interface MonoMap {
+  readonly name: string
+  readonly dom: string
+  readonly cod: string
+  readonly map: (x: string) => string
+}
+
+export interface FinPosCategory extends FiniteCategory<string, MonoMap> {
+  readonly traits: { readonly functionalArrows: true }
+  readonly one: () => string
+  readonly globals: (object: string) => MonoMap[]
+  readonly lookup: (name: string) => FinPosObj
+}
+
+const TERMINAL_NAME = "1"
+const TERMINAL_POINT = "⋆"
+
+function ensureObject(index: Record<string, FinPosObj>, name: string): FinPosObj {
+  const obj = index[name]
+  if (!obj) {
+    throw new Error(`FinPosCat: unknown object ${name}`)
+  }
+  return obj
+}
+
+export function FinPosCat(objects: readonly FinPosObj[]): FinPosCategory {
+  const byName: Record<string, FinPosObj> = {}
+  for (const obj of objects) {
+    byName[obj.name] = obj
+  }
+  if (!byName[TERMINAL_NAME]) {
+    const terminal = FinPos.one()
+    byName[terminal.name] = terminal
+  }
+
+  const objectList = Object.keys(byName)
+  const arrows: MonoMap[] = []
+
+  const eq = (f: MonoMap, g: MonoMap) =>
+    f.dom === g.dom &&
+    f.cod === g.cod &&
+    ensureObject(byName, f.dom).elems.every((x) => f.map(x) === g.map(x))
+
+  const id = (A: string): MonoMap => ({
+    name: `id_${A}`,
+    dom: A,
+    cod: A,
+    map: (x) => x,
+  })
+
+  const compose = (g: MonoMap, f: MonoMap): MonoMap => {
+    if (f.cod !== g.dom) {
+      throw new Error("FinPosCat: compose expects matching codomain/domain")
+    }
+    return {
+      name: `${g.name}∘${f.name}`,
+      dom: f.dom,
+      cod: g.cod,
+      map: (x) => g.map(f.map(x)),
+    }
+  }
+
+  const src = (f: MonoMap) => f.dom
+  const dst = (f: MonoMap) => f.cod
+
+  const globals = (A: string): MonoMap[] =>
+    ensureObject(byName, A).elems.map((a) => ({
+      name: `⟨${a}⟩`,
+      dom: TERMINAL_NAME,
+      cod: A,
+      map: (_x: string) => a,
+    }))
+
+  const category: FinPosCategory = {
+    objects: objectList,
+    arrows,
+    id,
+    compose,
+    src,
+    dst,
+    eq,
+    traits: { functionalArrows: true },
+    one: () => TERMINAL_NAME,
+    globals,
+    lookup: (name) => ensureObject(byName, name),
+  }
+
+  return category
+}
+
+export const FinPos = {
+  isMonotone(dom: FinPosObj, cod: FinPosObj, f: MonoMap): boolean {
+    for (const a of dom.elems) {
+      for (const b of dom.elems) {
+        if (dom.leq(a, b) && !cod.leq(f.map(a), f.map(b))) {
+          return false
+        }
+      }
+    }
+    return true
+  },
+  injective(dom: FinPosObj, _cod: FinPosObj, f: MonoMap): boolean {
+    const seen = new Map<string, string>()
+    for (const a of dom.elems) {
+      const image = f.map(a)
+      const previous = seen.get(image)
+      if (previous && previous !== a) {
+        return false
+      }
+      seen.set(image, a)
+    }
+    return true
+  },
+  surjective(_dom: FinPosObj, cod: FinPosObj, f: MonoMap): boolean {
+    const pending = new Set(cod.elems)
+    for (const a of _dom.elems) {
+      pending.delete(f.map(a))
+    }
+    return pending.size === 0
+  },
+  one(): FinPosObj {
+    return {
+      name: TERMINAL_NAME,
+      elems: [TERMINAL_POINT],
+      leq: () => true,
+    }
+  },
+  globals(A: FinPosObj): MonoMap[] {
+    return A.elems.map((a) => ({
+      name: `⟨${a}⟩`,
+      dom: TERMINAL_NAME,
+      cod: A.name,
+      map: (_x: string) => a,
+    }))
+  },
+}

--- a/models/finset-cat.ts
+++ b/models/finset-cat.ts
@@ -1,0 +1,258 @@
+import type { FiniteCategory } from "../finite-cat"
+import type { Factor } from "../kinds/epi-mono-factor"
+
+export type FinSetName = string
+export interface FuncArr {
+  readonly name: string
+  readonly dom: FinSetName
+  readonly cod: FinSetName
+  readonly map: (x: string) => string
+}
+
+export interface FinSetCategory extends FiniteCategory<FinSetName, FuncArr> {
+  readonly traits: { readonly functionalArrows: true; readonly balanced: true }
+  readonly isInjective: (arrow: FuncArr) => boolean
+  readonly isSurjective: (arrow: FuncArr) => boolean
+  readonly one: () => FinSetName
+  readonly globals: (object: FinSetName) => FuncArr[]
+  readonly carrier: (object: FinSetName) => readonly string[]
+  readonly counterexample: (
+    left: FuncArr,
+    right: FuncArr,
+  ) => { readonly input: string; readonly left: string; readonly right: string; readonly pretty: string } | null
+  readonly splitMonoWitness: (arrow: FuncArr) => FuncArr
+  readonly splitEpiWitness: (arrow: FuncArr) => FuncArr
+  readonly imageFactorisation: (arrow: FuncArr) => Factor<FinSetName, FuncArr>
+  readonly registerObject: (name: FinSetName, carrier: readonly string[]) => void
+}
+
+const TERMINAL_OBJECT: FinSetName = "1"
+const TERMINAL_POINT = "⋆"
+
+function requireCarrier(universe: Record<FinSetName, readonly string[]>, name: FinSetName): readonly string[] {
+  const carrier = universe[name]
+  if (!carrier) {
+    throw new Error(`FinSetCat: unknown carrier ${name}`)
+  }
+  return carrier
+}
+
+export function FinSetCat(universe: Record<FinSetName, readonly string[]>): FinSetCategory {
+  const carriers: Record<FinSetName, readonly string[]> = { ...universe }
+  if (!carriers[TERMINAL_OBJECT]) {
+    carriers[TERMINAL_OBJECT] = [TERMINAL_POINT] as const
+  }
+
+  const objects: FinSetName[] = Object.keys(carriers)
+  const arrows: FuncArr[] = []
+
+  const eq = (f: FuncArr, g: FuncArr) =>
+    f.dom === g.dom &&
+    f.cod === g.cod &&
+    requireCarrier(carriers, f.dom).every((x) => f.map(x) === g.map(x))
+
+  const id = (A: FinSetName): FuncArr => ({
+    name: `id_${A}`,
+    dom: A,
+    cod: A,
+    map: (x) => x,
+  })
+
+  const compose = (g: FuncArr, f: FuncArr): FuncArr => {
+    if (f.cod !== g.dom) {
+      throw new Error("FinSetCat: compose expects matching codomain/domain")
+    }
+    return {
+      name: `${g.name}∘${f.name}`,
+      dom: f.dom,
+      cod: g.cod,
+      map: (x) => g.map(f.map(x)),
+    }
+  }
+
+  const src = (f: FuncArr) => f.dom
+  const dst = (f: FuncArr) => f.cod
+
+  const globals = (A: FinSetName): FuncArr[] =>
+    requireCarrier(carriers, A).map((a) => ({
+      name: `⟨${a}⟩`,
+      dom: TERMINAL_OBJECT,
+      cod: A,
+      map: (_x: string) => a,
+    }))
+
+  const carrier = (A: FinSetName): readonly string[] => requireCarrier(carriers, A)
+
+  const counterexample = (
+    left: FuncArr,
+    right: FuncArr,
+  ): { readonly input: string; readonly left: string; readonly right: string; readonly pretty: string } | null => {
+    if (left.dom !== right.dom) return null
+    const domain = requireCarrier(carriers, left.dom)
+    for (const input of domain) {
+      const l = left.map(input)
+      const r = right.map(input)
+      if (l !== r) {
+        const lname = left.name ?? "λ"
+        const rname = right.name ?? "λ"
+        return {
+          input,
+          left: l,
+          right: r,
+          pretty: `${lname}(${input}) = ${l} ≠ ${rname}(${input}) = ${r}`,
+        }
+      }
+    }
+    return null
+  }
+
+  const registerObject = (name: FinSetName, elems: readonly string[]): void => {
+    const existing = carriers[name]
+    if (existing) {
+      if (existing.length !== elems.length || existing.some((value, index) => value !== elems[index])) {
+        throw new Error(`FinSetCat: conflicting carrier registration for ${name}`)
+      }
+      return
+    }
+    carriers[name] = [...elems]
+    if (!objects.includes(name)) objects.push(name)
+  }
+
+  const arraysEqual = (left: readonly string[], right: readonly string[]) =>
+    left.length === right.length && left.every((value, index) => value === right[index])
+
+  const ensureArrow = (arrow: FuncArr): FuncArr => {
+    const existing = arrows.find((candidate) => eq(candidate, arrow))
+    if (existing) return existing
+    arrows.push(arrow)
+    return arrow
+  }
+
+  const ensureObjectForCarrier = (proposedName: FinSetName, elems: readonly string[]): FinSetName => {
+    const match = objects.find((name) => arraysEqual(requireCarrier(carriers, name), elems))
+    if (match) {
+      registerObject(match, elems)
+      return match
+    }
+    let candidate = proposedName
+    let counter = 0
+    while (carriers[candidate]) {
+      counter += 1
+      candidate = `${proposedName}#${counter}`
+    }
+    registerObject(candidate, elems)
+    return candidate
+  }
+
+  const splitMonoWitness = (arrow: FuncArr): FuncArr => {
+    if (!isInjective(carriers, arrow)) {
+      throw new Error(`FinSetCat: arrow ${arrow.name} is not injective and cannot split as a mono`)
+    }
+    const domain = requireCarrier(carriers, arrow.dom)
+    if (domain.length === 0) {
+      throw new Error(`FinSetCat: arrow ${arrow.name} has empty domain; no section exists`)
+    }
+    const preimage: Record<string, string> = {}
+    for (const element of domain) {
+      const image = arrow.map(element)
+      if (preimage[image] === undefined) preimage[image] = element
+    }
+    const fallback = domain[0]!
+    return {
+      name: `${arrow.name}_section`,
+      dom: arrow.cod,
+      cod: arrow.dom,
+      map: (y: string) => preimage[y] ?? fallback,
+    }
+  }
+
+  const splitEpiWitness = (arrow: FuncArr): FuncArr => {
+    if (!isSurjective(carriers, arrow)) {
+      throw new Error(`FinSetCat: arrow ${arrow.name} is not surjective and cannot split as an epi`)
+    }
+    const domain = requireCarrier(carriers, arrow.dom)
+    const sections: Record<string, string> = {}
+    for (const element of domain) {
+      const image = arrow.map(element)
+      if (sections[image] === undefined) sections[image] = element
+    }
+    return {
+      name: `${arrow.name}_retract`,
+      dom: arrow.cod,
+      cod: arrow.dom,
+      map: (y: string) => {
+        const chosen = sections[y]
+        if (chosen !== undefined) return chosen
+        throw new Error(`FinSetCat: missing preimage for ${y} in split epi witness of ${arrow.name}`)
+      },
+    }
+  }
+
+  const category: FinSetCategory = {
+    objects,
+    arrows,
+    id,
+    compose,
+    src,
+    dst,
+    eq,
+    traits: { functionalArrows: true, balanced: true },
+    isInjective: (arrow) => isInjective(carriers, arrow),
+    isSurjective: (arrow) => isSurjective(carriers, arrow),
+    one: () => TERMINAL_OBJECT,
+    globals,
+    carrier,
+    counterexample,
+    splitMonoWitness,
+    splitEpiWitness,
+    imageFactorisation: (arrow) => {
+      const domain = requireCarrier(carriers, arrow.dom)
+      const imageElements: string[] = []
+      const seen = new Set<string>()
+      for (const element of domain) {
+        const mapped = arrow.map(element)
+        if (!seen.has(mapped)) {
+          seen.add(mapped)
+          imageElements.push(mapped)
+        }
+      }
+      const midName = ensureObjectForCarrier(`${arrow.cod}_im`, imageElements)
+      const epi = ensureArrow({
+        name: `${arrow.name}_epi`,
+        dom: arrow.dom,
+        cod: midName,
+        map: (x) => arrow.map(x),
+      })
+      const mono = ensureArrow({
+        name: `${midName}_incl_${arrow.cod}`,
+        dom: midName,
+        cod: arrow.cod,
+        map: (y) => y,
+      })
+      return { mid: midName, epi, mono }
+    },
+    registerObject,
+  }
+
+  return category
+}
+
+export function isInjective(universe: Record<FinSetName, readonly string[]>, f: FuncArr): boolean {
+  const elems = requireCarrier(universe, f.dom)
+  for (let i = 0; i < elems.length; i += 1) {
+    for (let j = i + 1; j < elems.length; j += 1) {
+      const a = elems[i]!
+      const b = elems[j]!
+      if (f.map(a) === f.map(b)) return false
+    }
+  }
+  return true
+}
+
+export function isSurjective(universe: Record<FinSetName, readonly string[]>, f: FuncArr): boolean {
+  const pending = new Set(requireCarrier(universe, f.cod))
+  for (const x of requireCarrier(universe, f.dom)) {
+    pending.delete(f.map(x))
+  }
+  return pending.size === 0
+}

--- a/models/finset-inverses.ts
+++ b/models/finset-inverses.ts
@@ -1,0 +1,77 @@
+import type { FinSetCategory, FuncArr } from "./finset-cat"
+
+const fallbackLabel = (arrow: FuncArr, flavour: "left" | "right"): string =>
+  `${arrow.name}_${flavour}Inv`
+
+/**
+ * Given an injective arrow f, construct a left inverse g with g ∘ f = id.
+ * Returns null when the arrow is not injective or when no such inverse can
+ * exist (for instance, when the domain is empty but the codomain is not).
+ */
+export const buildLeftInverseForInjective = (
+  category: FinSetCategory,
+  arrow: FuncArr,
+): FuncArr | null => {
+  if (!category.isInjective(arrow)) return null
+  const domain = category.carrier(arrow.dom)
+  const codomain = category.carrier(arrow.cod)
+  if (domain.length === 0) {
+    return codomain.length === 0
+      ? {
+          name: fallbackLabel(arrow, "left"),
+          dom: arrow.cod,
+          cod: arrow.dom,
+          map: (_x: string) => {
+            throw new Error("buildLeftInverseForInjective: unexpected evaluation on empty domain")
+          },
+        }
+      : null
+  }
+
+  const preimage: Record<string, string> = {}
+  for (const element of domain) {
+    const image = arrow.map(element)
+    if (preimage[image] === undefined) preimage[image] = element
+  }
+  const fallback = domain[0]!
+
+  return {
+    name: fallbackLabel(arrow, "left"),
+    dom: arrow.cod,
+    cod: arrow.dom,
+    map: (y: string) => preimage[y] ?? fallback,
+  }
+}
+
+/**
+ * Given a surjective arrow f, construct a right inverse g with f ∘ g = id.
+ * Returns null when the arrow fails to be surjective.
+ */
+export const buildRightInverseForSurjective = (
+  category: FinSetCategory,
+  arrow: FuncArr,
+): FuncArr | null => {
+  if (!category.isSurjective(arrow)) return null
+  const domain = category.carrier(arrow.dom)
+  const codomain = category.carrier(arrow.cod)
+
+  const sections: Record<string, string> = {}
+  for (const element of domain) {
+    const image = arrow.map(element)
+    if (sections[image] === undefined) sections[image] = element
+  }
+
+  const fallback = domain[0]
+
+  return {
+    name: fallbackLabel(arrow, "right"),
+    dom: arrow.cod,
+    cod: arrow.dom,
+    map: (y: string) => {
+      const chosen = sections[y]
+      if (chosen !== undefined) return chosen
+      if (fallback !== undefined) return fallback
+      throw new Error("buildRightInverseForSurjective: codomain element has no preimage")
+    },
+  }
+}

--- a/models/finset-splittings.ts
+++ b/models/finset-splittings.ts
@@ -1,0 +1,47 @@
+import type { FinSetCategory, FuncArr } from "./finset-cat"
+
+export interface SplitIdempotentResult {
+  readonly object: string
+  readonly retraction: FuncArr
+  readonly section: FuncArr
+}
+
+export const splitMonoWitness = (category: FinSetCategory, arrow: FuncArr): FuncArr =>
+  category.splitMonoWitness(arrow)
+
+export const splitEpiWitness = (category: FinSetCategory, arrow: FuncArr): FuncArr =>
+  category.splitEpiWitness(arrow)
+
+export const splitIdempotent = (
+  category: FinSetCategory,
+  arrow: FuncArr,
+): SplitIdempotentResult => {
+  if (category.src(arrow) !== category.dst(arrow)) {
+    throw new Error("splitIdempotent: arrow must be an endomorphism")
+  }
+  const composite = category.compose(arrow, arrow)
+  if (!category.eq(composite, arrow)) {
+    throw new Error("splitIdempotent: arrow is not idempotent")
+  }
+
+  const carrier = category.carrier(category.dst(arrow))
+  const fixed = carrier.filter((value) => arrow.map(value) === value)
+  const object = `${arrow.cod}_fix(${arrow.name})`
+  category.registerObject(object, fixed)
+
+  const retraction: FuncArr = {
+    name: `r_${arrow.name}`,
+    dom: arrow.cod,
+    cod: object,
+    map: (value: string) => arrow.map(value),
+  }
+
+  const section: FuncArr = {
+    name: `s_${arrow.name}`,
+    dom: object,
+    cod: arrow.cod,
+    map: (value: string) => value,
+  }
+
+  return { object, retraction, section }
+}

--- a/operations/rewriter.ts
+++ b/operations/rewriter.ts
@@ -1,0 +1,362 @@
+import type { FiniteCategory } from "../finite-cat"
+import { prettyArrow } from "../pretty"
+import { twoSidedInverses, rightInverses } from "../kinds/inverses"
+import { isMono, isEpi } from "../kinds/mono-epi"
+import { findMutualMonicFactorizations } from "../kinds/monic-factorization"
+import { epiMonoFactor } from "../kinds/epi-mono-factor"
+import { detectBalancedPromotions } from "../oracles/balanced"
+
+export interface NormalizeCompositeRewrite<Arr> {
+  readonly kind: "NormalizeComposite"
+  readonly path: readonly Arr[]
+  readonly removeStart: number
+  readonly removeCount: number
+  readonly description: string
+}
+
+export interface UpgradeToIsoRewrite<Arr> {
+  readonly kind: "UpgradeToIso"
+  readonly arrow: Arr
+  readonly inverse: Arr
+}
+
+export interface ReplaceWithIdentityRewrite<Arr> {
+  readonly kind: "ReplaceWithIdentity"
+  readonly composite: readonly [Arr, Arr]
+  readonly description: string
+}
+
+export interface MergeSubobjectsRewrite<Obj, Arr> {
+  readonly kind: "MergeSubobjects"
+  readonly left: Obj
+  readonly right: Obj
+  readonly forward: Arr
+  readonly backward: Arr
+}
+
+export interface MergeObjectsRewrite<Obj, Arr> {
+  readonly kind: "MergeObjects"
+  readonly left: Obj
+  readonly right: Obj
+  readonly forward: Arr
+  readonly backward: Arr
+}
+
+export interface FactorThroughEpiMonoRewrite<Arr> {
+  readonly kind: "FactorThroughEpiMono"
+  readonly arrow: Arr
+  readonly epi: Arr
+  readonly mono: Arr
+}
+
+export type Rewrite<Obj, Arr> =
+  | NormalizeCompositeRewrite<Arr>
+  | UpgradeToIsoRewrite<Arr>
+  | ReplaceWithIdentityRewrite<Arr>
+  | MergeSubobjectsRewrite<Obj, Arr>
+  | MergeObjectsRewrite<Obj, Arr>
+  | FactorThroughEpiMonoRewrite<Arr>
+
+export interface Suggestion<Obj, Arr> {
+  readonly id: string
+  readonly oracle: string
+  readonly severity: "safe" | "hint"
+  readonly message: string
+  readonly rewrites: ReadonlyArray<Rewrite<Obj, Arr>>
+}
+
+export interface OperationContext<Obj, Arr> {
+  readonly category: FiniteCategory<Obj, Arr>
+  readonly path?: readonly Arr[]
+  readonly focus?: Arr
+}
+
+export interface OperationRule<Obj, Arr> {
+  readonly name: string
+  readonly mode: "auto" | "suggest"
+  applicable(context: OperationContext<Obj, Arr>): boolean
+  apply(
+    context: OperationContext<Obj, Arr>,
+    makeId: () => string,
+  ): Suggestion<Obj, Arr> | null
+}
+
+const isoCancellationRule = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "IsoCancellation",
+  mode: "auto",
+  applicable: ({ path }) => Array.isArray(path) && path.length >= 2,
+  apply: (context, makeId) => {
+    const { category, path } = context
+    if (!path) return null
+    const rewrites: NormalizeCompositeRewrite<Arr>[] = []
+    for (let index = 0; index < path.length - 1; index += 1) {
+      const first = path[index]!
+      const second = path[index + 1]!
+      const inverses = twoSidedInverses(category, first)
+      if (inverses.some((candidate) => category.eq(candidate, second))) {
+        rewrites.push({
+          kind: "NormalizeComposite",
+          path,
+          removeStart: index,
+          removeCount: 2,
+          description: `${prettyArrow(category, first)} cancels ${prettyArrow(category, second)}`,
+        })
+      }
+    }
+    if (rewrites.length === 0) return null
+    const message =
+      rewrites.length === 1
+        ? `Cancel an inverse pair inside the composite.`
+        : `Cancel ${rewrites.length} inverse pairs inside the composite.`
+    return {
+      id: makeId(),
+      oracle: "IsoCancellation",
+      severity: "safe",
+      message,
+      rewrites,
+    }
+  },
+})
+
+const monicRightInverseUpgrade = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "MonoRightInverseUpgrade",
+  mode: "suggest",
+  applicable: ({ category, focus }) =>
+    focus !== undefined && isMono(category, focus) && rightInverses(category, focus).length > 0,
+  apply: (context, makeId) => {
+    const { category, focus } = context
+    if (!focus) return null
+    const candidates = rightInverses(category, focus)
+    for (const candidate of candidates) {
+      const gf = category.compose(candidate, focus)
+      const fg = category.compose(focus, candidate)
+      const idSrc = category.id(category.src(focus))
+      const idDst = category.id(category.dst(focus))
+      const leftOk = category.eq(gf, idSrc)
+      const rightOk = category.eq(fg, idDst)
+      if (!leftOk || !rightOk) continue
+      const rewrites: Rewrite<Obj, Arr>[] = [
+        { kind: "UpgradeToIso", arrow: focus, inverse: candidate },
+        {
+          kind: "ReplaceWithIdentity",
+          composite: [focus, candidate],
+          description: `${prettyArrow(category, focus)} ∘ ${prettyArrow(category, candidate)} = id`,
+        },
+        {
+          kind: "ReplaceWithIdentity",
+          composite: [candidate, focus],
+          description: `${prettyArrow(category, candidate)} ∘ ${prettyArrow(category, focus)} = id`,
+        },
+      ]
+      const message = `Promote ${prettyArrow(category, focus)} to an isomorphism via ${prettyArrow(
+        category,
+        candidate,
+      )}.`
+      return {
+        id: makeId(),
+        oracle: "MonicWithRightInverseIsIso",
+        severity: "hint",
+        message,
+        rewrites,
+      }
+    }
+    return null
+  },
+})
+
+const balancedMonoEpiUpgrade = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "BalancedMonoEpiUpgrade",
+  mode: "suggest",
+  applicable: ({ category, focus }) => {
+    if (!focus) return false
+    if (!category.traits?.balanced) return false
+    if (!isMono(category, focus) || !isEpi(category, focus)) return false
+    const promotions = detectBalancedPromotions(category, isMono, isEpi)
+    return promotions.some((promotion) => category.eq(promotion.arrow, focus))
+  },
+  apply: (context, makeId) => {
+    const { category, focus } = context
+    if (!focus) return null
+    if (!category.traits?.balanced) return null
+    const promotions = detectBalancedPromotions(category, isMono, isEpi).filter((promotion) =>
+      category.eq(promotion.arrow, focus),
+    )
+    if (promotions.length === 0) return null
+    const { inverse } = promotions[0]!
+    const rewrites: Rewrite<Obj, Arr>[] = [
+      { kind: "UpgradeToIso", arrow: focus, inverse },
+      {
+        kind: "ReplaceWithIdentity",
+        composite: [focus, inverse],
+        description: `${prettyArrow(category, focus)} ∘ ${prettyArrow(category, inverse)} = id`,
+      },
+      {
+        kind: "ReplaceWithIdentity",
+        composite: [inverse, focus],
+        description: `${prettyArrow(category, inverse)} ∘ ${prettyArrow(category, focus)} = id`,
+      },
+    ]
+    return {
+      id: makeId(),
+      oracle: "BalancedMonoEpicIsIso",
+      severity: "hint",
+      message: `Promote ${prettyArrow(category, focus)} to an isomorphism using balanced cancellability.`,
+      rewrites,
+    }
+  },
+})
+
+const epiMonoFactorisationRule = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "EpiMonoFactorisation",
+  mode: "suggest",
+  applicable: ({ category, focus }) => {
+    if (!focus) return false
+    return epiMonoFactor(category, focus) !== null
+  },
+  apply: (context, makeId) => {
+    const { category, focus } = context
+    if (!focus) return null
+    const factor = epiMonoFactor(category, focus)
+    if (!factor) return null
+    const message = `Factor ${prettyArrow(category, focus)} as ${prettyArrow(
+      category,
+      factor.epi,
+    )} followed by ${prettyArrow(category, factor.mono)}.`
+    const rewrites: Rewrite<Obj, Arr>[] = [
+      {
+        kind: "FactorThroughEpiMono",
+        arrow: focus,
+        epi: factor.epi,
+        mono: factor.mono,
+      },
+    ]
+    return {
+      id: makeId(),
+      oracle: "EpiMonoFactorization",
+      severity: "hint",
+      message,
+      rewrites,
+    }
+  },
+})
+
+const mutualMonicMerge = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "MutualMonicFactorisation",
+  mode: "suggest",
+  applicable: ({ category }) => findMutualMonicFactorizations(category).length > 0,
+  apply: (context, makeId) => {
+    const { category } = context
+    const witnesses = findMutualMonicFactorizations(category)
+    if (witnesses.length === 0) return null
+    const rewrites: MergeSubobjectsRewrite<Obj, Arr>[] = witnesses.map((witness) => ({
+      kind: "MergeSubobjects",
+      left: category.src(witness.left),
+      right: category.src(witness.right),
+      forward: witness.forward,
+      backward: witness.backward,
+    }))
+    const fragments = witnesses.map(
+      (witness) =>
+        `${prettyArrow(category, witness.left)} ↔ ${prettyArrow(category, witness.right)}`,
+    )
+    const message = `Treat ${fragments.join(", ")} as isomorphic subobjects.`
+    return {
+      id: makeId(),
+      oracle: "MonicFactorizationYieldsIso",
+      severity: "hint",
+      message,
+      rewrites,
+    }
+  },
+})
+
+const mergeObjectsFromIsos = <Obj, Arr>(): OperationRule<Obj, Arr> => ({
+  name: "MergeObjectsViaIso",
+  mode: "suggest",
+  applicable: ({ category }) =>
+    category.arrows.some((arrow) => twoSidedInverses(category, arrow).length > 0),
+  apply: (context, makeId) => {
+    const { category } = context
+    const rewrites: MergeObjectsRewrite<Obj, Arr>[] = []
+    const seen: Array<{ left: Arr; right: Arr }> = []
+
+    for (const arrow of category.arrows) {
+      const inverses = twoSidedInverses(category, arrow)
+      if (inverses.length === 0) continue
+
+      const sourceIdentity = category.id(category.src(arrow))
+      const targetIdentity = category.id(category.dst(arrow))
+
+      const alreadySeen = seen.some(
+        (entry) =>
+          (category.eq(entry.left, sourceIdentity) && category.eq(entry.right, targetIdentity)) ||
+          (category.eq(entry.left, targetIdentity) && category.eq(entry.right, sourceIdentity)),
+      )
+      if (alreadySeen) continue
+
+      const inverse = inverses[0]!
+      seen.push({ left: sourceIdentity, right: targetIdentity })
+      rewrites.push({
+        kind: "MergeObjects",
+        left: category.src(arrow),
+        right: category.dst(arrow),
+        forward: arrow,
+        backward: inverse,
+      })
+    }
+
+    if (rewrites.length === 0) return null
+
+    const description =
+      rewrites.length === 1
+        ? `Treat ${prettyArrow(category, rewrites[0]!.forward)} as an isomorphism of objects.`
+        : `Merge ${rewrites.length} pairs of isomorphic objects.`
+
+    return {
+      id: makeId(),
+      oracle: "IsoObjects",
+      severity: "hint",
+      message: description,
+      rewrites,
+    }
+  },
+})
+
+export class Rewriter<Obj, Arr> {
+  private readonly rules: OperationRule<Obj, Arr>[] = []
+
+  private counter = 0
+
+  constructor(rules: OperationRule<Obj, Arr>[] = []) {
+    for (const rule of rules) {
+      this.register(rule)
+    }
+  }
+
+  register(rule: OperationRule<Obj, Arr>): void {
+    this.rules.push(rule)
+  }
+
+  analyze(context: OperationContext<Obj, Arr>): Suggestion<Obj, Arr>[] {
+    const suggestions: Suggestion<Obj, Arr>[] = []
+    const makeId = () => {
+      this.counter += 1
+      return `rewrite-${this.counter}`
+    }
+    for (const rule of this.rules) {
+      if (!rule.applicable(context)) continue
+      const suggestion = rule.apply(context, makeId)
+      if (suggestion) suggestions.push(suggestion)
+    }
+    return suggestions
+  }
+}
+
+export const defaultOperationRules = <Obj, Arr>(): OperationRule<Obj, Arr>[] => [
+  isoCancellationRule(),
+  monicRightInverseUpgrade(),
+  balancedMonoEpiUpgrade(),
+  epiMonoFactorisationRule(),
+  mergeObjectsFromIsos(),
+  mutualMonicMerge(),
+]

--- a/operations/union-find.ts
+++ b/operations/union-find.ts
@@ -1,0 +1,55 @@
+export class UnionFind<T> {
+  private readonly parent = new Map<T, T>()
+  private readonly rank = new Map<T, number>()
+
+  constructor(items: Iterable<T> = []) {
+    for (const item of items) this.makeSet(item)
+  }
+
+  makeSet(item: T): void {
+    if (this.parent.has(item)) return
+    this.parent.set(item, item)
+    this.rank.set(item, 0)
+  }
+
+  find(item: T): T {
+    const parent = this.parent.get(item)
+    if (parent === undefined) {
+      throw new Error(`UnionFind: attempted to find unknown element ${String(item)}`)
+    }
+    if (!Object.is(parent, item)) {
+      const representative = this.find(parent)
+      this.parent.set(item, representative)
+      return representative
+    }
+    return item
+  }
+
+  union(a: T, b: T): T {
+    const rootA = this.find(a)
+    const rootB = this.find(b)
+    if (Object.is(rootA, rootB)) return rootA
+
+    const rankA = this.rank.get(rootA) ?? 0
+    const rankB = this.rank.get(rootB) ?? 0
+
+    if (rankA < rankB) {
+      this.parent.set(rootA, rootB)
+      return rootB
+    }
+    if (rankA > rankB) {
+      this.parent.set(rootB, rootA)
+      return rootA
+    }
+
+    this.parent.set(rootB, rootA)
+    this.rank.set(rootA, rankA + 1)
+    return rootA
+  }
+
+  representatives(): Map<T, T> {
+    const mapping = new Map<T, T>()
+    for (const key of this.parent.keys()) mapping.set(key, this.find(key))
+    return mapping
+  }
+}

--- a/oracles/balanced.ts
+++ b/oracles/balanced.ts
@@ -1,0 +1,47 @@
+import type { FiniteCategory } from "../finite-cat"
+
+export interface BalancedPromotion<Arr> {
+  readonly arrow: Arr
+  readonly inverse: Arr
+}
+
+const findTwoSidedInverse = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  arrow: Arr,
+): Arr | null => {
+  const source = category.src(arrow)
+  const target = category.dst(arrow)
+  const idSource = category.id(source)
+  const idTarget = category.id(target)
+
+  for (const candidate of category.arrows) {
+    if (category.src(candidate) !== target) continue
+    if (category.dst(candidate) !== source) continue
+    const left = category.compose(candidate, arrow)
+    if (!category.eq(left, idSource)) continue
+    const right = category.compose(arrow, candidate)
+    if (!category.eq(right, idTarget)) continue
+    return candidate
+  }
+
+  return null
+}
+
+export const detectBalancedPromotions = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  isMono: (category: FiniteCategory<Obj, Arr>, arrow: Arr) => boolean,
+  isEpi: (category: FiniteCategory<Obj, Arr>, arrow: Arr) => boolean,
+): BalancedPromotion<Arr>[] => {
+  if (!category.traits?.balanced) return []
+
+  const promotions: BalancedPromotion<Arr>[] = []
+  for (const arrow of category.arrows) {
+    if (!isMono(category, arrow)) continue
+    if (!isEpi(category, arrow)) continue
+    const inverse = findTwoSidedInverse(category, arrow)
+    if (!inverse) continue
+    promotions.push({ arrow, inverse })
+  }
+
+  return promotions
+}

--- a/oracles/inverses-oracles.ts
+++ b/oracles/inverses-oracles.ts
@@ -1,0 +1,71 @@
+import type { FiniteCategory } from "../finite-cat"
+import { isEpi, isMono } from "../kinds/mono-epi"
+import { leftInverses, rightInverses, twoSidedInverses } from "../kinds/inverses"
+import { isIso } from "../kinds/iso"
+import { prettyArrow } from "../pretty"
+
+type AnyCat = FiniteCategory<unknown, unknown>
+type AnyArr = unknown
+
+export interface ArrowOracle {
+  readonly id: string
+  readonly title: string
+  readonly applies: (input: { cat: AnyCat; arrow: AnyArr }) => boolean
+  readonly check: (input: { cat: AnyCat; arrow: AnyArr }) => boolean
+  readonly explain: (input: { cat: AnyCat; arrow: AnyArr }) => string
+}
+
+const decorate = (cat: AnyCat) => ({
+  ...cat,
+  isMono: (arrow: AnyArr) => isMono(cat, arrow),
+  isEpi: (arrow: AnyArr) => isEpi(cat, arrow),
+})
+
+const arrowLabel = (cat: AnyCat, arrow: AnyArr): string => prettyArrow(decorate(cat), arrow)
+
+export const LeftInverseImpliesMono: ArrowOracle = {
+  id: "LeftInverseImpliesMono",
+  title: "Left inverse ⇒ monomorphism",
+  applies: ({ cat, arrow }) => leftInverses(cat, arrow).length > 0,
+  check: ({ cat, arrow }) => isMono(cat, arrow),
+  explain: ({ cat, arrow }) =>
+    `${arrowLabel(cat, arrow)} has a left inverse, therefore it must be monic.`,
+}
+
+export const RightInverseImpliesEpi: ArrowOracle = {
+  id: "RightInverseImpliesEpi",
+  title: "Right inverse ⇒ epimorphism",
+  applies: ({ cat, arrow }) => rightInverses(cat, arrow).length > 0,
+  check: ({ cat, arrow }) => isEpi(cat, arrow),
+  explain: ({ cat, arrow }) =>
+    `${arrowLabel(cat, arrow)} has a right inverse, so it is necessarily epic.`,
+}
+
+export const IsoIsMonoAndEpi: ArrowOracle = {
+  id: "IsoIsMonoAndEpi",
+  title: "Isomorphisms are mono and epi",
+  applies: ({ cat, arrow }) => twoSidedInverses(cat, arrow).length > 0,
+  check: ({ cat, arrow }) => isMono(cat, arrow) && isEpi(cat, arrow),
+  explain: ({ cat, arrow }) =>
+    `${arrowLabel(cat, arrow)} admits a two-sided inverse, so it is both monic and epic.`,
+}
+
+export const MonoWithRightInverseIsIso: ArrowOracle = {
+  id: "MonoWithRightInverseIsIso",
+  title: "Monic with right inverse ⇒ isomorphism",
+  applies: ({ cat, arrow }) =>
+    isMono(cat, arrow) && rightInverses(cat, arrow).length > 0,
+  check: ({ cat, arrow }) => isIso(cat, arrow),
+  explain: ({ cat, arrow }) =>
+    `${arrowLabel(cat, arrow)} is monic and has a right inverse, therefore Theorem 22 upgrades it to an isomorphism.`,
+}
+
+export const EpiWithLeftInverseIsIso: ArrowOracle = {
+  id: "EpiWithLeftInverseIsIso",
+  title: "Epic with left inverse ⇒ isomorphism",
+  applies: ({ cat, arrow }) =>
+    isEpi(cat, arrow) && leftInverses(cat, arrow).length > 0,
+  check: ({ cat, arrow }) => isIso(cat, arrow),
+  explain: ({ cat, arrow }) =>
+    `${arrowLabel(cat, arrow)} is epic and admits a left inverse, so it must be an isomorphism.`,
+}

--- a/oracles/iso-axioms.ts
+++ b/oracles/iso-axioms.ts
@@ -1,0 +1,128 @@
+import type { FiniteCategory } from "../finite-cat"
+import { isoWitness as findIsoWitness } from "../kinds/iso"
+import type { IsoWitness } from "../kinds/iso"
+
+export interface IsoAxiomResult<Arr> {
+  readonly holds: boolean
+  readonly detail?: string
+  readonly witness?: IsoWitness<Arr> | Arr
+}
+
+const arrowLabel = <Obj, Arr>(category: FiniteCategory<Obj, Arr>, arrow: Arr): string => {
+  const name = (arrow as { readonly name?: unknown }).name
+  const src = category.src(arrow)
+  const dst = category.dst(arrow)
+  const tag = typeof name === "string" ? name : "⟨anon⟩"
+  return `${tag}:${String(src)}→${String(dst)}`
+}
+
+const twoSidedCheck = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr>,
+  forward: Arr,
+  candidate: Arr,
+) => {
+  const gof = category.compose(candidate, forward)
+  const fog = category.compose(forward, candidate)
+  const srcId = category.id(category.src(forward))
+  const dstId = category.id(category.dst(forward))
+  const leftOk = category.eq(gof, srcId)
+  const rightOk = category.eq(fog, dstId)
+  return { leftOk, rightOk, gof, fog, srcId, dstId }
+}
+
+export const IsoAxioms = {
+  identityIsIso<Obj, Arr>(
+    category: FiniteCategory<Obj, Arr>,
+    object: Obj,
+  ): IsoAxiomResult<Arr> {
+    const identity = category.id(object)
+    const witness = findIsoWitness(category, identity)
+    if (witness) {
+      return { holds: true, witness }
+    }
+    return {
+      holds: false,
+      detail: `Identity ${arrowLabel(category, identity)} does not have a two-sided inverse.`,
+    }
+  },
+
+  uniqueInverse<Obj, Arr>(
+    category: FiniteCategory<Obj, Arr>,
+    arrow: Arr,
+    g: Arr,
+    h: Arr,
+  ): IsoAxiomResult<Arr> {
+    const first = twoSidedCheck(category, arrow, g)
+    const second = twoSidedCheck(category, arrow, h)
+
+    if (!first.leftOk || !first.rightOk || !second.leftOk || !second.rightOk) {
+      const details = [
+        !first.leftOk || !first.rightOk
+          ? `g fails: g∘f=${arrowLabel(category, first.gof)}; f∘g=${arrowLabel(category, first.fog)}`
+          : undefined,
+        !second.leftOk || !second.rightOk
+          ? `h fails: h∘f=${arrowLabel(category, second.gof)}; f∘h=${arrowLabel(category, second.fog)}`
+          : undefined,
+      ]
+        .filter((entry): entry is string => entry !== undefined)
+        .join("; ")
+      return {
+        holds: false,
+        detail: details.length > 0 ? details : "Provided arrows are not two-sided inverses.",
+      }
+    }
+
+    if (!category.eq(g, h)) {
+      return {
+        holds: false,
+        detail: `Inverse of ${arrowLabel(category, arrow)} must be unique, but g=${arrowLabel(category, g)} and h=${arrowLabel(category, h)} differ.`,
+      }
+    }
+
+    const isoG = findIsoWitness(category, g)
+    const isoH = findIsoWitness(category, h)
+    if (!isoG || !isoH) {
+      return {
+        holds: false,
+        detail: `Inverses should themselves be isomorphisms (g iso? ${!!isoG}, h iso? ${!!isoH}).`,
+      }
+    }
+
+    return { holds: true }
+  },
+
+  closedUnderComposition<Obj, Arr>(
+    category: FiniteCategory<Obj, Arr>,
+    f: Arr,
+    g: Arr,
+  ): IsoAxiomResult<Arr> {
+    const witnessF = findIsoWitness(category, f)
+    const witnessG = findIsoWitness(category, g)
+    if (!witnessF || !witnessG) {
+      const missing = [
+        witnessF ? undefined : `f ${arrowLabel(category, f)} is not an isomorphism`,
+        witnessG ? undefined : `g ${arrowLabel(category, g)} is not an isomorphism`,
+      ]
+        .filter((entry): entry is string => entry !== undefined)
+        .join("; ")
+      return { holds: false, detail: missing }
+    }
+
+    const composite = category.compose(g, f)
+    const expectedInverse = category.compose(witnessF.inverse, witnessG.inverse)
+    const check = twoSidedCheck(category, composite, expectedInverse)
+    if (check.leftOk && check.rightOk) {
+      return { holds: true, witness: { forward: composite, inverse: expectedInverse } }
+    }
+
+    const compositeLabel = arrowLabel(category, composite)
+    const expectedLabel = arrowLabel(category, expectedInverse)
+    return {
+      holds: false,
+      detail: `Expected inverse for ${compositeLabel} to be ${expectedLabel}, but g∘f∘(f⁻¹∘g⁻¹)=${arrowLabel(category, check.fog)} and (f⁻¹∘g⁻¹)∘(g∘f)=${arrowLabel(category, check.gof)}.`,
+    }
+  },
+}
+
+export { findIsoWitness as isoWitness }
+export { isIso } from "../kinds/iso"

--- a/oracles/monic-factorization.ts
+++ b/oracles/monic-factorization.ts
@@ -1,0 +1,19 @@
+import type { FiniteCategory } from "../finite-cat"
+import {
+  type FactorisationCheckResult,
+  verifyMutualMonicFactorizations,
+} from "../kinds/monic-factorization"
+
+export interface CategoryOracle {
+  readonly id: string
+  readonly title: string
+  readonly check: <Obj, Arr>(
+    category: FiniteCategory<Obj, Arr>,
+  ) => FactorisationCheckResult<Arr>
+}
+
+export const MonicFactorizationYieldsIso: CategoryOracle = {
+  id: "MonicFactorizationYieldsIso",
+  title: "Mutually factoring monomorphisms yield isomorphisms",
+  check: (category) => verifyMutualMonicFactorizations(category),
+}

--- a/pretty.ts
+++ b/pretty.ts
@@ -1,0 +1,28 @@
+import type { FiniteCategory } from "./finite-cat"
+
+type MonoEpiAware<Obj, Arr> = FiniteCategory<Obj, Arr> & {
+  readonly isMono?: (arrow: Arr) => boolean
+  readonly isEpi?: (arrow: Arr) => boolean
+}
+
+const arrowName = (arrow: unknown): string => {
+  const candidate = (arrow as { name?: unknown }).name
+  return typeof candidate === "string" ? candidate : String(arrow)
+}
+
+export const arrowGlyph = <Obj, Arr>(
+  category: MonoEpiAware<Obj, Arr>,
+  arrow: Arr,
+): string => {
+  const mono = category.isMono?.(arrow) ?? false
+  const epi = category.isEpi?.(arrow) ?? false
+  if (mono && epi) return "⇄"
+  if (mono) return "↪"
+  if (epi) return "↠"
+  return "→"
+}
+
+export const prettyArrow = <Obj, Arr>(
+  category: MonoEpiAware<Obj, Arr>,
+  arrow: Arr,
+): string => `${arrowGlyph(category, arrow)} ${arrowName(arrow)}`

--- a/pushout-toy.ts
+++ b/pushout-toy.ts
@@ -1,9 +1,52 @@
 import type { FiniteCategory } from "./finite-cat";
-import type { PushoutCalculator } from "./pushout";
-import { makeFinitePushoutCalculator } from "./pushout";
+import type { PushoutCalc, PushoutData } from "./pushout";
 
-export function makeToyPushouts<Obj, Arr>(
-  base: FiniteCategory<Obj, Arr>,
-): PushoutCalculator<Obj, Arr> {
-  return makeFinitePushoutCalculator(base);
+export function makeToyPushouts<Obj, Arr>(base: FiniteCategory<Obj, Arr>): PushoutCalc<Obj, Arr> {
+  const pushout = (f: Arr, h: Arr): PushoutData<Obj, Arr> => {
+    if (base.src(f) !== base.src(h)) {
+      throw new Error("makeToyPushouts: pushout legs must share a domain.");
+    }
+
+    for (const apex of base.objects) {
+      for (const fromDomain of base.arrows) {
+        if (base.src(fromDomain) !== base.dst(f) || base.dst(fromDomain) !== apex) continue;
+        for (const fromAnchor of base.arrows) {
+          if (base.src(fromAnchor) !== base.dst(h) || base.dst(fromAnchor) !== apex) continue;
+          const left = base.compose(fromDomain, f);
+          const right = base.compose(fromAnchor, h);
+          if (base.eq(left, right)) {
+            return {
+              apex,
+              fromDomain,
+              fromAnchor,
+              Q: apex,
+              iA: fromDomain,
+              iZ: fromAnchor,
+            };
+          }
+        }
+      }
+    }
+
+    throw new Error("makeToyPushouts: no pushout found for the supplied legs.");
+  };
+
+  const coinduce = (
+    j: Arr,
+    pushoutOfDst: PushoutData<Obj, Arr>,
+    pushoutOfSrc: PushoutData<Obj, Arr>,
+  ): Arr => {
+    for (const candidate of base.arrows) {
+      if (base.src(candidate) !== pushoutOfSrc.apex || base.dst(candidate) !== pushoutOfDst.apex) continue;
+      const leftDomain = base.compose(candidate, pushoutOfSrc.fromDomain);
+      const rightDomain = base.compose(pushoutOfDst.fromDomain, j);
+      if (!base.eq(leftDomain, rightDomain)) continue;
+      const leftAnchor = base.compose(candidate, pushoutOfSrc.fromAnchor);
+      if (!base.eq(leftAnchor, pushoutOfDst.fromAnchor)) continue;
+      return candidate;
+    }
+    throw new Error("makeToyPushouts: no coinduced map witnesses the universal property.");
+  };
+
+  return { pushout, coinduce };
 }

--- a/pushout.ts
+++ b/pushout.ts
@@ -1,12 +1,29 @@
 import type { FiniteCategory } from "./finite-cat";
 
+/**
+ * Data witnessing a pushout square for f:X→A and h:X→Z.
+ *
+ * Historically the toolkit exposed the fields as { apex, fromDomain, fromAnchor }:
+ *  - `apex` is the codomain Q of the two injections,
+ *  - `fromDomain` is the arrow A→Q induced from the codomain of f,
+ *  - `fromAnchor` is the arrow Z→Q induced from the codomain of h.
+ *
+ * During the refactor that introduced the finite pushout fixtures we temporarily
+ * renamed these to the more pushout-diagram flavoured { Q, iA, iZ }.  That made it
+ * harder to compare the coslice reindexing code with its pullback counterpart,
+ * so we now surface both views simultaneously for clarity and backwards
+ * compatibility.
+ */
 export interface PushoutData<Obj, Arr> {
   readonly apex: Obj;
   readonly fromDomain: Arr;
   readonly fromAnchor: Arr;
+  readonly Q: Obj;
+  readonly iA: Arr;
+  readonly iZ: Arr;
 }
 
-export interface PushoutCalculator<Obj, Arr> {
+export interface PushoutCalc<Obj, Arr> {
   pushout(f: Arr, h: Arr): PushoutData<Obj, Arr>;
   coinduce(
     j: Arr,
@@ -15,9 +32,9 @@ export interface PushoutCalculator<Obj, Arr> {
   ): Arr;
 }
 
-export function makeFinitePushoutCalculator<Obj, Arr>(
+export function makeFinitePushoutCalc<Obj, Arr>(
   base: FiniteCategory<Obj, Arr>,
-): PushoutCalculator<Obj, Arr> {
+): PushoutCalc<Obj, Arr> {
   const pushout = (f: Arr, h: Arr): PushoutData<Obj, Arr> => {
     let fallback: PushoutData<Obj, Arr> | undefined;
     const domainIdentity = base.id(base.dst(f));
@@ -31,7 +48,14 @@ export function makeFinitePushoutCalculator<Obj, Arr>(
           const left = base.compose(fromDomain, f);
           const right = base.compose(fromAnchor, h);
           if (!base.eq(left, right)) continue;
-          const candidate = { apex, fromDomain, fromAnchor } as const;
+          const candidate = {
+            apex,
+            fromDomain,
+            fromAnchor,
+            Q: apex,
+            iA: fromDomain,
+            iZ: fromAnchor,
+          } as const;
           if (base.eq(fromDomain, domainIdentity)) return candidate;
           if (base.eq(fromAnchor, anchorIdentity)) return candidate;
           if (!fallback) fallback = candidate;
@@ -40,7 +64,7 @@ export function makeFinitePushoutCalculator<Obj, Arr>(
     }
 
     if (fallback) return fallback;
-    throw new Error("makeFinitePushoutCalculator: no pushout found for the supplied arrows.");
+    throw new Error("makeFinitePushoutCalc: no pushout found for the supplied arrows.");
   };
 
   const coinduce = (
@@ -57,8 +81,15 @@ export function makeFinitePushoutCalculator<Obj, Arr>(
       if (!base.eq(leftAnchor, pushoutOfDst.fromAnchor)) continue;
       return candidate;
     }
-    throw new Error("makeFinitePushoutCalculator: no mediating arrow satisfies the pushout conditions.");
+    throw new Error("makeFinitePushoutCalc: no mediating arrow satisfies the pushout conditions.");
   };
 
   return { pushout, coinduce };
 }
+
+/** @deprecated use {@link PushoutCalc} */
+export type PushoutCalculator<Obj, Arr> = PushoutCalc<Obj, Arr>;
+/** @deprecated use {@link PushoutData} */
+export type LegacyPushoutData<Obj, Arr> = PushoutData<Obj, Arr>;
+/** @deprecated use {@link makeFinitePushoutCalc} */
+export const makeFinitePushoutCalculator = makeFinitePushoutCalc;

--- a/test/coslice-reindexing.spec.ts
+++ b/test/coslice-reindexing.spec.ts
@@ -1,84 +1,18 @@
 import { describe, expect, it } from "vitest";
-import type { FiniteCategory } from "../finite-cat";
 import { makeCoslice } from "../slice-cat";
 import { makeCoslicePrecomposition } from "../coslice-precompose";
 import { makeCosliceReindexingFunctor } from "../coslice-reindexing";
 import { makeFinitePushoutCalculator } from "../pushout";
-
-type Obj = "X" | "Z" | "A" | "B" | "Qf" | "Qg";
-
-type Arrow = {
-  readonly name: string;
-  readonly src: Obj;
-  readonly dst: Obj;
-};
-
-const objects: readonly Obj[] = ["X", "Z", "A", "B", "Qf", "Qg"];
-
-const arrowByName = new Map<string, Arrow>();
-const makeArrow = (name: string, src: Obj, dst: Obj): Arrow => {
-  const arrow = { name, src, dst } as const;
-  arrowByName.set(name, arrow);
-  return arrow;
-};
-
-const arrows: readonly Arrow[] = [
-  ...objects.map((object) => makeArrow(`id_${object}`, object, object)),
-  makeArrow("f", "X", "A"),
-  makeArrow("g", "X", "B"),
-  makeArrow("h", "X", "Z"),
-  makeArrow("j", "A", "B"),
-  makeArrow("qAf", "A", "Qf"),
-  makeArrow("qZf", "Z", "Qf"),
-  makeArrow("liftF", "X", "Qf"),
-  makeArrow("qBg", "B", "Qg"),
-  makeArrow("qZg", "Z", "Qg"),
-  makeArrow("liftG", "X", "Qg"),
-  makeArrow("qBgJ", "A", "Qg"),
-  makeArrow("u", "Qf", "Qg"),
-];
-
-const getArrow = (name: string): Arrow => {
-  const arrow = arrowByName.get(name);
-  if (!arrow) throw new Error(`unknown arrow ${name}`);
-  return arrow;
-};
-
-const compose = (g: Arrow, f: Arrow): Arrow => {
-  if (f.dst !== g.src) throw new Error(`compose mismatch for ${g.name} ∘ ${f.name}`);
-  if (f.name.startsWith("id_")) return getArrow(g.name);
-  if (g.name.startsWith("id_")) return getArrow(f.name);
-  if (f.name === "f" && g.name === "j") return getArrow("g");
-  if (f.name === "f" && g.name === "qAf") return getArrow("liftF");
-  if (f.name === "h" && g.name === "qZf") return getArrow("liftF");
-  if (f.name === "g" && g.name === "qBg") return getArrow("liftG");
-  if (f.name === "h" && g.name === "qZg") return getArrow("liftG");
-  if (f.name === "qAf" && g.name === "u") return getArrow("qBgJ");
-  if (f.name === "j" && g.name === "qBg") return getArrow("qBgJ");
-  if (f.name === "f" && g.name === "qBgJ") return getArrow("liftG");
-  if (f.name === "qZf" && g.name === "u") return getArrow("qZg");
-  if (f.name === "liftF" && g.name === "u") return getArrow("liftG");
-  throw new Error(`unsupported composition ${g.name} ∘ ${f.name}`);
-};
-
-const BaseCategory: FiniteCategory<Obj, Arrow> = {
-  objects,
-  arrows,
-  id: (object) => getArrow(`id_${object}`),
-  compose,
-  src: (arrow) => arrow.src,
-  dst: (arrow) => arrow.dst,
-  eq: (a, b) => a.name === b.name,
-};
+import { PushoutCategory, getArrow } from "./pushout-fixture";
 
 describe("coslice precomposition and pushout reindexing", () => {
-  const cosliceOverZ = makeCoslice(BaseCategory, "Z");
-  const cosliceOverX = makeCoslice(BaseCategory, "X");
+  const cosliceOverZ = makeCoslice(PushoutCategory, "Z");
+  const cosliceOverX = makeCoslice(PushoutCategory, "X");
   const h = getArrow("h");
-  const pushouts = makeFinitePushoutCalculator(BaseCategory);
+  const pushouts = makeFinitePushoutCalculator(PushoutCategory);
 
   it("precomposes coslice objects and arrows along h", () => {
-    const functor = makeCoslicePrecomposition(BaseCategory, h, "X", "Z");
+    const functor = makeCoslicePrecomposition(PushoutCategory, h, "X", "Z");
     const object = cosliceOverZ.objects.find((candidate) => candidate.codomain === "Qf");
     expect(object).toBeDefined();
     const image = functor.F0(object!);
@@ -94,7 +28,7 @@ describe("coslice precomposition and pushout reindexing", () => {
   });
 
   it("reindexes coslice data along pushouts", () => {
-    const functor = makeCosliceReindexingFunctor(BaseCategory, pushouts, h, "X", "Z");
+    const functor = makeCosliceReindexingFunctor(PushoutCategory, pushouts, h, "X", "Z");
     const object = cosliceOverX.objects.find((candidate) => candidate.arrowFromAnchor.name === "f");
     expect(object).toBeDefined();
     const image = functor.F0(object!);
@@ -113,14 +47,20 @@ describe("coslice precomposition and pushout reindexing", () => {
     const f = getArrow("f");
     const data = pushouts.pushout(f, h);
     expect(data.apex).toBe("Qf");
+    expect(data.Q).toBe(data.apex);
     expect(data.fromDomain.name).toBe("qAf");
+    expect(data.iA.name).toBe("qAf");
     expect(data.fromAnchor.name).toBe("qZf");
+    expect(data.iZ.name).toBe("qZf");
 
     const g = getArrow("g");
     const dst = pushouts.pushout(g, h);
     expect(dst.apex).toBe("Qg");
+    expect(dst.Q).toBe(dst.apex);
     expect(dst.fromDomain.name).toBe("qBg");
+    expect(dst.iA.name).toBe("qBg");
     expect(dst.fromAnchor.name).toBe("qZg");
+    expect(dst.iZ.name).toBe("qZg");
 
     const mediating = pushouts.coinduce(getArrow("j"), dst, data);
     expect(mediating.name).toBe("u");

--- a/test/epi-stable-under-pushout.spec.ts
+++ b/test/epi-stable-under-pushout.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest"
+import { makeToyPushouts } from "../pushout-toy"
+import { isEpi } from "../kinds/mono-epi"
+import { PushoutCategory } from "./pushout-fixture"
+
+const C = PushoutCategory
+const pushouts = makeToyPushouts(C)
+
+const epis = C.arrows.filter((arrow) => isEpi(C, arrow))
+const hs = C.arrows
+
+describe("epis are stable under pushouts in the fixture category", () => {
+  it("co-legs of pushouts preserve epimorphisms", () => {
+    for (const e of epis) {
+      for (const h of hs) {
+        if (C.src(e) !== C.src(h)) continue
+        const data = pushouts.pushout(e, h)
+        expect(isEpi(C, data.iZ)).toBe(true)
+      }
+    }
+  })
+})

--- a/test/fingroup-kernel.spec.ts
+++ b/test/fingroup-kernel.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { FinGrpCat, type FinGrpObj, type Hom } from "../models/fingroup-cat"
+import { kernelElements, nonMonoWitness } from "../models/fingroup-kernel"
+import { isMono } from "../kinds/mono-epi"
+
+const Z2: FinGrpObj = {
+  name: "Z2",
+  elems: ["0", "1"] as const,
+  e: "0",
+  mul: (a, b) => ((Number(a) + Number(b)) % 2).toString(),
+  inv: (a) => a,
+}
+
+const Z3: FinGrpObj = {
+  name: "Z3",
+  elems: ["0", "1", "2"] as const,
+  e: "0",
+  mul: (a, b) => ((Number(a) + Number(b)) % 3).toString(),
+  inv: (a) => ((3 - Number(a)) % 3).toString(),
+}
+
+describe("Finite Grp kernels provide non-mono witnesses", () => {
+  const nonInjective: Hom = { name: "collapse", dom: "Z2", cod: "Z3", map: (_a) => "0" }
+  const injective: Hom = { name: "embed", dom: "Z2", cod: "Z3", map: (a) => a }
+
+  it("computes kernel elements", () => {
+    expect(kernelElements(Z2, Z3, injective)).toEqual(["0"])
+    expect(kernelElements(Z2, Z3, nonInjective)).toEqual(["0", "1"])
+  })
+
+  it("builds explicit fork witnesses when kernel has size > 1", () => {
+    const witness = nonMonoWitness(Z2, Z3, nonInjective)
+    expect(witness).not.toBeNull()
+    const { subgroup, inclusion, collapse } = witness!
+
+    const category = FinGrpCat([Z2, Z3, subgroup])
+    ;(category.arrows as Hom[]).push(nonInjective, inclusion, collapse)
+
+    const collapseCompose = category.compose(nonInjective, collapse)
+    const inclusionCompose = category.compose(nonInjective, inclusion)
+
+    expect(category.eq(collapseCompose, inclusionCompose)).toBe(true)
+    expect(category.eq(collapse, inclusion)).toBe(false)
+    expect(isMono(category, nonInjective)).toBe(false)
+  })
+
+  it("returns null when the kernel is trivial", () => {
+    expect(nonMonoWitness(Z2, Z3, injective)).toBeNull()
+  })
+})

--- a/test/finset-epi-mono-factor.spec.ts
+++ b/test/finset-epi-mono-factor.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest"
+import { FinSetCat, type FinSetName, type FuncArr } from "../models/finset-cat"
+import { epiMonoFactor, epiMonoMiddleIso, type Factor } from "../kinds/epi-mono-factor"
+import { isEpi, isMono } from "../kinds/mono-epi"
+
+describe("FinSet epi–mono factorisations", () => {
+  const universe = {
+    A: ["a1", "a2", "a3"],
+    B: ["b1", "b2", "b3", "b4"],
+  } as const
+
+  const category = FinSetCat(universe)
+
+  const arrow: FuncArr = {
+    name: "f",
+    dom: "A",
+    cod: "B",
+    map: (x) => {
+      switch (x) {
+        case "a1":
+          return "b1"
+        case "a2":
+          return "b2"
+        default:
+          return "b2"
+      }
+    },
+  }
+
+  ;(category.arrows as FuncArr[]).push(arrow)
+
+  it("builds the image factorisation for every function", () => {
+    const factor = epiMonoFactor(category, arrow)
+    expect(factor).not.toBeNull()
+    if (!factor) return
+
+    expect(category.eq(category.compose(factor.mono, factor.epi), arrow)).toBe(true)
+    expect(isEpi(category, factor.epi)).toBe(true)
+    expect(isMono(category, factor.mono)).toBe(true)
+
+    const midCarrier = category.carrier(factor.mid)
+    expect(midCarrier).toEqual(["b1", "b2"])
+
+    const secondFactor = epiMonoFactor(category, arrow)
+    expect(secondFactor).not.toBeNull()
+    if (!secondFactor) return
+    expect(secondFactor.mid).toBe(factor.mid)
+    expect(category.eq(secondFactor.epi, factor.epi)).toBe(true)
+    expect(category.eq(secondFactor.mono, factor.mono)).toBe(true)
+  })
+
+  it("produces an isomorphism between different epi–mono middles", () => {
+    category.registerObject("AltImage", ["b2", "b1"])
+    const altEpi: FuncArr = {
+      name: "alt_epi",
+      dom: "A",
+      cod: "AltImage",
+      map: (x) => arrow.map(x),
+    }
+    const altMono: FuncArr = {
+      name: "alt_mono",
+      dom: "AltImage",
+      cod: "B",
+      map: (y) => y,
+    }
+    ;(category.arrows as FuncArr[]).push(altEpi, altMono)
+
+    const canonical = epiMonoFactor(category, arrow)
+    expect(canonical).not.toBeNull()
+    if (!canonical) return
+
+    const manual: Factor<FinSetName, FuncArr> = {
+      mid: "AltImage",
+      epi: altEpi,
+      mono: altMono,
+    }
+    expect(category.eq(category.compose(manual.mono, manual.epi), arrow)).toBe(true)
+
+    const forwardBridge: FuncArr = {
+      name: "image_to_alt",
+      dom: canonical.mid,
+      cod: manual.mid,
+      map: (y) => y,
+    }
+    const backwardBridge: FuncArr = {
+      name: "alt_to_image",
+      dom: manual.mid,
+      cod: canonical.mid,
+      map: (y) => y,
+    }
+    ;(category.arrows as FuncArr[]).push(forwardBridge, backwardBridge)
+
+    const iso = epiMonoMiddleIso(category, canonical, manual)
+    expect(iso).not.toBeNull()
+    if (!iso) return
+
+    const forward = iso.forward
+    const backward = iso.backward
+    expect(category.src(forward)).toBe(canonical.mid)
+    expect(category.dst(forward)).toBe(manual.mid)
+    expect(category.eq(category.compose(forward, canonical.epi), manual.epi)).toBe(true)
+    expect(category.eq(category.compose(manual.mono, forward), canonical.mono)).toBe(true)
+    expect(category.eq(category.compose(backward, forward), category.id(canonical.mid))).toBe(true)
+    expect(category.eq(category.compose(forward, backward), category.id(manual.mid))).toBe(true)
+  })
+})

--- a/test/finset-epi-witness.spec.ts
+++ b/test/finset-epi-witness.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { FinSetCat, type FuncArr, isSurjective } from "../models/finset-cat"
+import { isEpi } from "../kinds/mono-epi"
+import { nonEpiWitnessInSet } from "../kinds/epi-witness-set"
+
+describe("Finite Set epi diagnostics", () => {
+  it("builds an explicit witness for non-surjective arrows", () => {
+    const baseUniverse = {
+      C: ["c1", "c2"] as const,
+      D: ["d1", "d2", "d3"] as const,
+    }
+
+    const nonSurj: FuncArr = {
+      name: "f",
+      dom: "C",
+      cod: "D",
+      map: (x) => (x === "c1" ? "d1" : "d2"),
+    }
+
+    expect(isSurjective(baseUniverse, nonSurj)).toBe(false)
+
+    const witness = nonEpiWitnessInSet(baseUniverse, nonSurj)
+    expect(witness).not.toBeNull()
+
+    const { codomain, g, h, missingElement } = witness!
+    const extendedUniverse: Record<string, readonly string[]> = {
+      ...baseUniverse,
+      [codomain.name]: codomain.elems,
+    }
+    const category = FinSetCat(extendedUniverse)
+    ;(category.arrows as FuncArr[]).push(nonSurj, g, h)
+
+    const gf = category.compose(g, nonSurj)
+    const hf = category.compose(h, nonSurj)
+    expect(category.eq(gf, hf)).toBe(true)
+    expect(category.eq(g, h)).toBe(false)
+    expect(isEpi(category, nonSurj)).toBe(false)
+    expect(missingElement).toBe("d3")
+    expect(h.map(missingElement)).toBe("1")
+  })
+
+  it("returns null for surjective arrows", () => {
+    const universe = {
+      C3: ["c1", "c2", "c3"] as const,
+      D: ["d1", "d2", "d3"] as const,
+    }
+
+    const surj: FuncArr = {
+      name: "σ",
+      dom: "C3",
+      cod: "D",
+      map: (x) => (x === "c1" ? "d1" : x === "c2" ? "d2" : "d3"),
+    }
+
+    expect(isSurjective(universe, surj)).toBe(true)
+    expect(nonEpiWitnessInSet(universe, surj)).toBeNull()
+
+    const category = FinSetCat(universe)
+    ;(category.arrows as FuncArr[]).push(surj)
+    expect(isEpi(category, surj)).toBe(true)
+  })
+})

--- a/test/finset-mono-epi.spec.ts
+++ b/test/finset-mono-epi.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { FinSetCat, isInjective, isSurjective, type FuncArr } from "../models/finset-cat"
+import { isMono, isEpi } from "../kinds/mono-epi"
+
+describe("FinSet model matches mono/epi cancellability", () => {
+  const universe = {
+    A: ["a1", "a2"],
+    B: ["b1", "b2", "b3"],
+  } as const
+
+  const category = FinSetCat(universe)
+
+  const inj: FuncArr = { name: "i", dom: "A", cod: "B", map: (x) => (x === "a1" ? "b1" : "b2") }
+  const nonInj: FuncArr = { name: "n", dom: "A", cod: "B", map: () => "b1" }
+  const surj: FuncArr = {
+    name: "s",
+    dom: "B",
+    cod: "A",
+    map: (y) => (y === "b3" ? "a2" : "a1"),
+  }
+  const nonSurj: FuncArr = { name: "t", dom: "B", cod: "A", map: () => "a1" }
+
+  ;(category.arrows as FuncArr[]).push(inj, nonInj, surj, nonSurj)
+
+  it("exposes functional traits and global elements", () => {
+    expect(category.traits?.functionalArrows).toBe(true)
+    expect(category.one()).toBe("1")
+    expect(category.globals("A")).toHaveLength(universe.A.length)
+  })
+
+  it("monomorphisms correspond to injective functions", () => {
+    expect(isMono(category, inj)).toBe(isInjective(universe, inj))
+    expect(isMono(category, nonInj)).toBe(isInjective(universe, nonInj))
+  })
+
+  it("epimorphisms correspond to surjective functions", () => {
+    expect(isEpi(category, surj)).toBe(isSurjective(universe, surj))
+    expect(isEpi(category, nonSurj)).toBe(isSurjective(universe, nonSurj))
+  })
+})

--- a/test/finset-splittings.spec.ts
+++ b/test/finset-splittings.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import { splitEpiWitness, splitIdempotent, splitMonoWitness } from "../models/finset-splittings"
+import { isIdempotent, projectorFromSection } from "../kinds/idempotent"
+
+describe("FinSet split witnesses and idempotents", () => {
+  const universe = {
+    C: ["c1", "c2"],
+    D: ["d1", "d2", "d3"],
+    E: ["e1", "e2"],
+    Empty: [] as const,
+  }
+
+  const category = FinSetCat(universe)
+
+  const injective: FuncArr = {
+    name: "inj",
+    dom: "C",
+    cod: "D",
+    map: (value) => (value === "c1" ? "d1" : "d2"),
+  }
+
+  const surjective: FuncArr = {
+    name: "surj",
+    dom: "D",
+    cod: "E",
+    map: (value) => (value === "d3" ? "e2" : "e1"),
+  }
+
+  const emptyMono: FuncArr = {
+    name: "empty",
+    dom: "Empty",
+    cod: "D",
+    map: () => "d1",
+  }
+
+  ;(category.arrows as FuncArr[]).push(injective, surjective, emptyMono)
+
+  it("provides a canonical section for every non-empty injective map", () => {
+    const section = splitMonoWitness(category, injective)
+    const composite = category.compose(section, injective)
+    expect(category.eq(composite, category.id("C"))).toBe(true)
+  })
+
+  it("provides a canonical retraction for every surjective map", () => {
+    const retraction = splitEpiWitness(category, surjective)
+    const composite = category.compose(surjective, retraction)
+    expect(category.eq(composite, category.id("E"))).toBe(true)
+  })
+
+  it("refuses to split an empty-domain mono", () => {
+    expect(() => splitMonoWitness(category, emptyMono)).toThrow()
+  })
+
+  it("builds an idempotent from a section/retraction pair", () => {
+    const retraction = splitMonoWitness(category, injective)
+    const projector = projectorFromSection(category, injective, retraction)
+    expect(isIdempotent(category, projector)).toBe(true)
+  })
+
+  it("splits an idempotent onto its fixed points", () => {
+    const retraction = splitMonoWitness(category, injective)
+    const projector = projectorFromSection(category, injective, retraction)
+    const { object, retraction: r, section } = splitIdempotent(category, projector)
+    expect(category.eq(category.compose(r, section), category.id(object))).toBe(true)
+    expect(category.eq(category.compose(section, r), projector)).toBe(true)
+    expect(category.carrier(object)).toEqual(["d1", "d2"])
+  })
+})

--- a/test/fork-utils.spec.ts
+++ b/test/fork-utils.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import { forkCommutes, isMonoByForks } from "../kinds/fork"
+import { isMono, isEpi } from "../kinds/mono-epi"
+import { isMonoByGlobals } from "../traits/global-elements"
+
+describe("fork utilities and functional traits", () => {
+  const universe = {
+    A: ["a1", "a2"],
+    B: ["b1", "b2"],
+  } as const
+  const C = FinSetCat(universe)
+
+  const inj: FuncArr = { name: "inj", dom: "A", cod: "B", map: (x) => (x === "a1" ? "b1" : "b2") }
+  const nonInj: FuncArr = { name: "collapse", dom: "A", cod: "B", map: () => "b1" }
+  const surj: FuncArr = { name: "surj", dom: "B", cod: "A", map: (y) => (y === "b2" ? "a2" : "a1") }
+  const nonSurj: FuncArr = { name: "const", dom: "B", cod: "A", map: () => "a1" }
+
+  const [eta1, eta2] = C.globals("A")
+  ;(C.arrows as FuncArr[]).push(inj, nonInj, surj, nonSurj, eta1, eta2)
+
+  it("detects commuting forks witnessing non-monic arrows", () => {
+    expect(forkCommutes(C, nonInj, eta1, eta2)).toBe(true)
+    expect(isMonoByForks(C, nonInj)).toBe(false)
+  })
+
+  it("agrees with cancellability and fast-path diagnostics", () => {
+    expect(isMono(C, inj)).toBe(true)
+    expect(isMono(C, nonInj)).toBe(false)
+    expect(isMonoByForks(C, inj)).toBe(true)
+    expect(isMonoByGlobals(C, inj)).toBe(true)
+    expect(isMonoByGlobals(C, nonInj)).toBe(false)
+  })
+
+  it("uses functional traits to accelerate epi checks", () => {
+    expect(isEpi(C, surj)).toBe(true)
+    expect(isEpi(C, nonSurj)).toBe(false)
+  })
+})

--- a/test/grp-mono-epi.spec.ts
+++ b/test/grp-mono-epi.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { FinGrpCat, FinGrp, type FinGrpObj, type Hom } from "../models/fingroup-cat"
+import { isMono, isEpi } from "../kinds/mono-epi"
+
+const Z2: FinGrpObj = {
+  name: "Z2",
+  elems: ["0", "1"] as const,
+  e: "0",
+  mul: (a, b) => ((Number(a) + Number(b)) % 2).toString(),
+  inv: (a) => a,
+}
+
+const Z4: FinGrpObj = {
+  name: "Z4",
+  elems: ["0", "1", "2", "3"] as const,
+  e: "0",
+  mul: (a, b) => ((Number(a) + Number(b)) % 4).toString(),
+  inv: (a) => ((4 - Number(a)) % 4).toString(),
+}
+
+describe("Finite Grp: mono⇔injective, epi⇔surjective", () => {
+  const category = FinGrpCat([Z2, Z4])
+
+  const inj: Hom = { name: "i", dom: "Z2", cod: "Z4", map: (a) => ((Number(a) * 2) % 4).toString() }
+  const nonInj: Hom = { name: "n", dom: "Z2", cod: "Z4", map: (_a) => "0" }
+  const surj: Hom = { name: "s", dom: "Z4", cod: "Z2", map: (a) => (Number(a) % 2).toString() }
+  const nonSurj: Hom = { name: "c", dom: "Z4", cod: "Z2", map: (_a) => "0" }
+  const idZ4: Hom = { name: "id", dom: "Z4", cod: "Z4", map: (a) => a }
+
+  ;(category.arrows as Hom[]).push(inj, nonInj, surj, nonSurj, idZ4)
+
+  it("hom sanity", () => {
+    expect(FinGrp.isHom(Z2, Z4, inj)).toBe(true)
+    expect(FinGrp.isHom(Z2, Z4, nonInj)).toBe(true)
+    expect(FinGrp.isHom(Z4, Z2, surj)).toBe(true)
+    expect(FinGrp.isHom(Z4, Z2, nonSurj)).toBe(true)
+    expect(FinGrp.isHom(Z4, Z4, idZ4)).toBe(true)
+  })
+
+  it("monomorphisms correspond to injective homomorphisms", () => {
+    expect(isMono(category, inj)).toBe(true)
+    expect(isMono(category, nonInj)).toBe(false)
+    expect(isMono(category, inj)).toBe(FinGrp.injective(Z2, Z4, inj))
+    expect(isMono(category, nonInj)).toBe(FinGrp.injective(Z2, Z4, nonInj))
+  })
+
+  it("epimorphisms correspond to surjective homomorphisms", () => {
+    expect(isEpi(category, surj)).toBe(true)
+    expect(isEpi(category, idZ4)).toBe(true)
+    expect(isEpi(category, nonSurj)).toBe(false)
+    expect(isEpi(category, surj)).toBe(FinGrp.surjective(Z4, Z2, surj))
+    expect(isEpi(category, idZ4)).toBe(FinGrp.surjective(Z4, Z4, idZ4))
+    expect(isEpi(category, nonSurj)).toBe(FinGrp.surjective(Z4, Z2, nonSurj))
+  })
+})

--- a/test/inverses-oracles.spec.ts
+++ b/test/inverses-oracles.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import { buildLeftInverseForInjective, buildRightInverseForSurjective } from "../models/finset-inverses"
+import { checkInverseEquation } from "../diagnostics"
+import {
+  IsoIsMonoAndEpi,
+  LeftInverseImpliesMono,
+  RightInverseImpliesEpi,
+  MonoWithRightInverseIsIso,
+  EpiWithLeftInverseIsIso,
+} from "../oracles/inverses-oracles"
+
+describe("Inverse diagnostics and oracle implications", () => {
+  const universe = {
+    C: ["c1", "c2", "c3"],
+    D: ["d1", "d2"],
+    A: ["a"],
+    B: ["b"],
+  } as const
+
+  const category = FinSetCat(universe)
+  const registry = category.arrows as FuncArr[]
+
+  const s: FuncArr = {
+    name: "s",
+    dom: "C",
+    cod: "D",
+    map: (x) => (x === "c1" ? "d1" : "d2"),
+  }
+  const r: FuncArr = {
+    name: "r",
+    dom: "D",
+    cod: "C",
+    map: (d) => (d === "d1" ? "c1" : "c2"),
+  }
+  const u: FuncArr = {
+    name: "u",
+    dom: "A",
+    cod: "B",
+    map: () => "b",
+  }
+  const v: FuncArr = {
+    name: "v",
+    dom: "B",
+    cod: "A",
+    map: () => "a",
+  }
+
+  registry.push(s, r, u, v)
+
+  it("reports counterexamples when inverse equations fail", () => {
+    const bad: FuncArr = { name: "bad", dom: "D", cod: "C", map: () => "c1" }
+    const result = checkInverseEquation(category, s, bad, "right")
+    expect(result.ok).toBe(false)
+    expect(result.msg).toMatch(/≠/)
+    expect(result.msg).toMatch(/d1/)
+  })
+
+  it("constructs inverses for injective and surjective maps", () => {
+    const left = buildLeftInverseForInjective(category, r)
+    expect(left).not.toBeNull()
+    const right = buildRightInverseForSurjective(category, s)
+    expect(right).not.toBeNull()
+
+    for (const d of universe.D) {
+      expect(left!.map(r.map(d))).toBe(d)
+      expect(s.map(right!.map(d))).toBe(d)
+    }
+  })
+
+  it("oracles detect the expected cancellability properties", () => {
+    expect(LeftInverseImpliesMono.applies({ cat: category, arrow: r })).toBe(true)
+    expect(LeftInverseImpliesMono.check({ cat: category, arrow: r })).toBe(true)
+
+    expect(RightInverseImpliesEpi.applies({ cat: category, arrow: s })).toBe(true)
+    expect(RightInverseImpliesEpi.check({ cat: category, arrow: s })).toBe(true)
+
+    expect(IsoIsMonoAndEpi.applies({ cat: category, arrow: u })).toBe(true)
+    expect(IsoIsMonoAndEpi.check({ cat: category, arrow: u })).toBe(true)
+
+    expect(MonoWithRightInverseIsIso.applies({ cat: category, arrow: u })).toBe(true)
+    expect(MonoWithRightInverseIsIso.check({ cat: category, arrow: u })).toBe(true)
+
+    expect(EpiWithLeftInverseIsIso.applies({ cat: category, arrow: v })).toBe(true)
+    expect(EpiWithLeftInverseIsIso.check({ cat: category, arrow: v })).toBe(true)
+  })
+})

--- a/test/iso-axioms.spec.ts
+++ b/test/iso-axioms.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { IsoAxioms, isIso } from "../oracles/iso-axioms"
+import { makeIsoReadyFinSet, makeIsoReadyFinPos, makeIsoReadyFinGrp, FinPos } from "../adapters/iso-ready"
+import type { FuncArr } from "../models/finset-cat"
+import type { MonoMap, FinPosObj } from "../models/finpos-cat"
+import type { FinGrpObj, Hom } from "../models/fingroup-cat"
+
+describe("Isomorphism axioms", () => {
+  it("identifies identity arrows as isomorphisms in FinSet", () => {
+    const category = makeIsoReadyFinSet({ A: ["a", "b"], B: ["x", "y"], C: ["p", "q"] })
+
+    const iso: FuncArr = {
+      name: "swap",
+      dom: "A",
+      cod: "B",
+      map: (value) => (value === "a" ? "x" : "y"),
+    }
+    ;(category.arrows as FuncArr[]).push(iso)
+
+    const identityResult = IsoAxioms.identityIsIso(category, "A")
+    expect(identityResult.holds).toBe(true)
+
+    expect(isIso(category, iso)).toBe(true)
+
+    const [inverse] = category.candidatesToInvert(iso)
+    expect(inverse).toBeDefined()
+
+    const unique = IsoAxioms.uniqueInverse(category, iso, inverse, inverse)
+    expect(unique.holds).toBe(true)
+
+    const iso2: FuncArr = {
+      name: "permute",
+      dom: "B",
+      cod: "C",
+      map: (value) => (value === "x" ? "p" : "q"),
+    }
+    ;(category.arrows as FuncArr[]).push(iso2)
+    const composition = IsoAxioms.closedUnderComposition(category, iso, iso2)
+    expect(composition.holds).toBe(true)
+  })
+
+  it("exposes failures of uniqueness when candidates disagree", () => {
+    const category = makeIsoReadyFinSet({ A: ["0", "1"], B: ["u", "v"] })
+    const iso: FuncArr = {
+      name: "flip",
+      dom: "A",
+      cod: "B",
+      map: (value) => (value === "0" ? "u" : "v"),
+    }
+    ;(category.arrows as FuncArr[]).push(iso)
+
+    const [inverse] = category.candidatesToInvert(iso)
+    expect(inverse).toBeDefined()
+
+    const bogus: FuncArr = {
+      name: "const",
+      dom: "B",
+      cod: "A",
+      map: (_value) => "0",
+    }
+
+    const result = IsoAxioms.uniqueInverse(category, iso, inverse, bogus)
+    expect(result.holds).toBe(false)
+    expect(result.detail).toBeDefined()
+    expect(result.detail).toContain("fails")
+  })
+
+  it("provides counterexamples where mono + epi ≠ iso in FinPos", () => {
+    const discrete: FinPosObj = { name: "Disc", elems: ["a", "b"], leq: (x, y) => x === y }
+    const chain: FinPosObj = {
+      name: "Chain",
+      elems: ["a", "b"],
+      leq: (x, y) => x === y || x === "a",
+    }
+    const category = makeIsoReadyFinPos([discrete, chain, FinPos.one()])
+
+    const f: MonoMap = {
+      name: "incl",
+      dom: "Disc",
+      cod: "Chain",
+      map: (value) => value,
+    }
+    ;(category.arrows as MonoMap[]).push(f)
+
+    expect(isIso(category, f)).toBe(false)
+  })
+
+  it("detects non-isomorphisms in FinGrp while validating identity isos", () => {
+    const Z2: FinGrpObj = {
+      name: "Z2",
+      elems: ["0", "1"],
+      e: "0",
+      mul: (a, b) => ((Number(a) + Number(b)) % 2).toString(),
+      inv: (a) => a,
+    }
+    const category = makeIsoReadyFinGrp([Z2])
+
+    const identity = IsoAxioms.identityIsIso(category, "Z2")
+    expect(identity.holds).toBe(true)
+
+    const constant: Hom = {
+      name: "const0",
+      dom: "Z2",
+      cod: "Z2",
+      map: () => "0",
+    }
+    ;(category.arrows as Hom[]).push(constant)
+    expect(isIso(category, constant)).toBe(false)
+  })
+})

--- a/test/iso-homset.spec.ts
+++ b/test/iso-homset.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest"
+import type { FiniteCategory } from "../finite-cat"
+import { IsoRegistry } from "../iso/registry"
+import { GoalRewriter } from "../iso/goal-rewriter"
+import type { IsoWitness } from "../iso/types"
+
+interface Arrow {
+  readonly id: string
+  readonly src: Obj
+  readonly dst: Obj
+}
+
+type Obj = "A" | "C" | "D"
+
+type ArrowName =
+  | "1_A"
+  | "1_C"
+  | "1_D"
+  | "f"
+  | "g"
+  | "u"
+  | "f∘u"
+  | "v"
+  | "v∘g"
+
+type ArrowMap = Record<ArrowName, Arrow>
+
+type ComposeKey = `${ArrowName}|${ArrowName}`
+
+const buildCategory = (): FiniteCategory<Obj, Arrow> => {
+  const make = (id: ArrowName, src: Obj, dst: Obj): Arrow => ({ id, src, dst })
+  const arrows: ArrowMap = {
+    "1_A": make("1_A", "A", "A"),
+    "1_C": make("1_C", "C", "C"),
+    "1_D": make("1_D", "D", "D"),
+    f: make("f", "C", "D"),
+    g: make("g", "D", "C"),
+    u: make("u", "A", "C"),
+    "f∘u": make("f∘u", "A", "D"),
+    v: make("v", "C", "A"),
+    "v∘g": make("v∘g", "D", "A"),
+  }
+
+  const table: Record<ComposeKey, Arrow> = {
+    "1_A|1_A": arrows["1_A"],
+    "1_C|1_C": arrows["1_C"],
+    "1_D|1_D": arrows["1_D"],
+    "f|1_C": arrows.f,
+    "1_D|f": arrows.f,
+    "g|1_D": arrows.g,
+    "1_C|g": arrows.g,
+    "f∘u|1_A": arrows["f∘u"],
+    "1_D|f∘u": arrows["f∘u"],
+    "u|1_A": arrows.u,
+    "1_C|u": arrows.u,
+    "v|1_C": arrows.v,
+    "1_A|v": arrows.v,
+    "v∘g|1_D": arrows["v∘g"],
+    "1_A|v∘g": arrows["v∘g"],
+    "g|f": arrows["1_C"],
+    "f|g": arrows["1_D"],
+    "f|u": arrows["f∘u"],
+    "g|f∘u": arrows.u,
+    "v|g": arrows["v∘g"],
+    "v∘g|f": arrows.v,
+  }
+
+  const compose = (g: Arrow, f: Arrow): Arrow => {
+    if (f.dst !== g.src) throw new Error(`non-composable ${f.id} then ${g.id}`)
+    if (f.id.startsWith("1_")) return g
+    if (g.id.startsWith("1_")) return f
+    const key: ComposeKey = `${g.id}|${f.id}`
+    const result = table[key]
+    if (!result) throw new Error(`missing composite for ${key}`)
+    return result
+  }
+
+  const list = Object.values(arrows)
+
+  return {
+    objects: ["A", "C", "D"],
+    arrows: list,
+    id: (object) => arrows[`1_${object}` as ArrowName],
+    compose,
+    src: (arrow) => arrow.src,
+    dst: (arrow) => arrow.dst,
+    eq: (x, y) => x.id === y.id,
+  }
+}
+
+describe("Iso registry and Hom-set transport", () => {
+  const category = buildCategory()
+  const registry = new IsoRegistry(category)
+  const witness: IsoWitness<Arrow> = { forward: category.arrows.find((a) => a.id === "f")!, backward: category.arrows.find((a) => a.id === "g")! }
+
+  registry.addIsomorphism("C", "D", witness)
+
+  it("unifies representatives when adding an isomorphism", () => {
+    expect(registry.representative("C")).toBe(registry.representative("D"))
+  })
+
+  it("transports arrows between Hom-sets", () => {
+    const linker = registry.createHomSetLinker("C", "D")
+    expect(linker).not.toBeNull()
+    const incoming = linker!.transportInto("A", "C")
+    expect(incoming.original.map((arrow) => arrow.id)).toEqual(["u"])
+    expect(incoming.transported.map((arrow) => arrow.id)).toEqual(["f∘u"])
+    expect(incoming.roundTrip.map((arrow) => arrow.id)).toEqual(["u"])
+
+    const outgoing = linker!.transportOutOf("A", "C")
+    expect(outgoing.original.map((arrow) => arrow.id)).toEqual(["v"])
+    expect(outgoing.transported.map((arrow) => arrow.id)).toEqual(["v∘g"])
+    expect(outgoing.roundTrip.map((arrow) => arrow.id)).toEqual(["v"])
+  })
+
+  it("rewrites goals across isomorphic objects", () => {
+    const rewriter = new GoalRewriter(category, registry)
+    const incoming = rewriter.rewriteIncomingGoal("C", "D", (arrow) => category.eq(arrow, category.arrows.find((a) => a.id === "u")!))
+    expect(incoming).not.toBeNull()
+    const transported = incoming!.liftOriginal(category.arrows.find((a) => a.id === "u")!)
+    expect(transported.id).toBe("f∘u")
+    expect(incoming!.predicateOnTarget(transported)).toBe(true)
+    const roundTrip = incoming!.lowerToOriginal(transported)
+    expect(roundTrip.id).toBe("u")
+
+    const outgoing = rewriter.rewriteOutgoingGoal("A", "C", "D", (arrow) => category.eq(arrow, category.arrows.find((a) => a.id === "v")!))
+    expect(outgoing).not.toBeNull()
+    const lifted = outgoing!.liftOriginal(category.arrows.find((a) => a.id === "v")!)
+    expect(lifted.id).toBe("v∘g")
+    expect(outgoing!.predicateOnTarget(lifted)).toBe(true)
+    expect(outgoing!.lowerToOriginal(lifted).id).toBe("v")
+  })
+
+  it("respects skeletal categories", () => {
+    const skeletal = new IsoRegistry(buildCategory(), { isSkeletal: true })
+    expect(() => skeletal.addIsomorphism("C", "D", witness)).toThrow(/Skeletal category forbids/)
+  })
+})

--- a/test/kinds/epi-mono-factor.spec.ts
+++ b/test/kinds/epi-mono-factor.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest"
+import type { FiniteCategory } from "../../finite-cat"
 import { makeToyCategory, arrows } from "./toy-category"
 import { epiMonoFactor } from "../../kinds/epi-mono-factor"
 import { isMono, isEpi } from "../../kinds/mono-epi"
@@ -12,5 +13,37 @@ describe("kinds/epi-mono-factor", () => {
     expect(isEpi(category, factor!.epi)).toBe(true)
     expect(isMono(category, factor!.mono)).toBe(true)
     expect(category.eq(category.compose(factor!.mono, factor!.epi), arrows.f)).toBe(true)
+  })
+
+  it("returns null when no epi–mono factorisation exists", () => {
+    type Obj = "C"
+    type Arrow = { readonly name: string; readonly source: Obj; readonly target: Obj }
+
+    const id: Arrow = { name: "id_C", source: "C", target: "C" }
+    const i: Arrow = { name: "i", source: "C", target: "C" }
+
+    const arrowsList: Arrow[] = [id, i]
+
+    const compose = (first: Arrow, second: Arrow): Arrow => {
+      if (second === id) return first
+      if (first === id) return second
+      return i
+    }
+
+    const eq = (left: Arrow, right: Arrow) => left.name === right.name
+
+    const miniCategory: FiniteCategory<Obj, Arrow> = {
+      objects: ["C"],
+      arrows: arrowsList,
+      id: () => id,
+      compose: (first, second) => compose(first, second),
+      src: (arrow) => arrow.source,
+      dst: (arrow) => arrow.target,
+      eq,
+    }
+
+    expect(isMono(miniCategory, i)).toBe(false)
+    expect(isEpi(miniCategory, i)).toBe(false)
+    expect(epiMonoFactor(miniCategory, i)).toBeNull()
   })
 })

--- a/test/kinds/groupoid.spec.ts
+++ b/test/kinds/groupoid.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { catFromGroup, type FinGroup } from "../../kinds/group-as-category"
+import { catFromGroup, groupFromOneObjectGroupoid, type FinGroup } from "../../kinds/group-as-category"
 import { isGroupoid, actionGroupoid } from "../../kinds/groupoid"
 
 describe("kinds/groupoid", () => {
@@ -13,6 +13,23 @@ describe("kinds/groupoid", () => {
   it("treats a group as a one-object groupoid", () => {
     const category = catFromGroup(z2)
     expect(isGroupoid(category)).toBe(true)
+  })
+
+  it("recovers the original group from its one-object groupoid", () => {
+    const category = catFromGroup(z2)
+    const { group } = groupFromOneObjectGroupoid(category)
+
+    const names = group.elements.map((arrow) => (arrow as any).element).sort()
+    expect(names).toEqual(["e", "s"])
+
+    const elementByName = (name: string) =>
+      group.elements.find((arrow) => (arrow as any).element === name)!
+
+    const s = elementByName("s")
+    const product = group.multiply(s, s)
+    expect((product as any).element).toBe("e")
+    const inverse = group.inverse(s)
+    expect((inverse as any).element).toBe("s")
   })
 
   it("builds an action groupoid for Z2 acting on three points", () => {

--- a/test/kinds/mono-epi-laws.spec.ts
+++ b/test/kinds/mono-epi-laws.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { makeToyCategory, arrows } from "./toy-category"
+import {
+  composeEpisAreEpi,
+  composeMonosAreMono,
+  identityIsEpi,
+  identityIsMono,
+  leftFactorOfEpi,
+  rightFactorOfMono,
+  saturateMonoEpi,
+} from "../../kinds/mono-epi-laws"
+
+describe("Mono/Epi inference laws", () => {
+  const category = makeToyCategory()
+
+  it("treats identities as mono and epi", () => {
+    for (const object of category.objects) {
+      expect(identityIsMono(category, object)).toBe(true)
+      expect(identityIsEpi(category, object)).toBe(true)
+    }
+  })
+
+  it("preserves monos and epis under composition", () => {
+    expect(composeMonosAreMono(category, arrows.g, arrows.f)).toBe(true)
+    expect(composeEpisAreEpi(category, arrows.g, arrows.f)).toBe(true)
+  })
+
+  it("inherits mono/epi properties from composites", () => {
+    expect(rightFactorOfMono(category, arrows.g, arrows.f)).toBe(true)
+    expect(leftFactorOfEpi(category, arrows.g, arrows.f)).toBe(true)
+  })
+
+  it("saturates mono/epi facts across the category", () => {
+    const closure = saturateMonoEpi(category)
+    expect(closure.idMonos.size).toBe(category.objects.length)
+    expect(closure.idEpis.size).toBe(category.objects.length)
+    expect(closure.monos.has(arrows.f)).toBe(true)
+    expect(closure.monos.has(arrows.g)).toBe(true)
+    expect(closure.epis.has(arrows.f)).toBe(true)
+    expect(closure.epis.has(arrows.g)).toBe(true)
+  })
+})

--- a/test/monic-factorization.spec.ts
+++ b/test/monic-factorization.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import {
+  findMutualMonicFactorizations,
+  verifyMutualMonicFactorizations,
+} from "../kinds/monic-factorization"
+import { MonicFactorizationYieldsIso } from "../oracles/monic-factorization"
+
+describe("Monic factorisation oracles", () => {
+  const universe = {
+    R: ["r1", "r2"],
+    S: ["s1", "s2"],
+    X: ["x1", "x2"],
+  } as const
+
+  const category = FinSetCat(universe)
+  const registry = category.arrows as FuncArr[]
+
+  const r: FuncArr = {
+    name: "r",
+    dom: "R",
+    cod: "X",
+    map: (value) => (value === "r1" ? "x1" : "x2"),
+  }
+  const s: FuncArr = {
+    name: "s",
+    dom: "S",
+    cod: "X",
+    map: (value) => (value === "s1" ? "x1" : "x2"),
+  }
+  const g: FuncArr = {
+    name: "g",
+    dom: "R",
+    cod: "S",
+    map: (value) => (value === "r1" ? "s1" : "s2"),
+  }
+  const h: FuncArr = {
+    name: "h",
+    dom: "S",
+    cod: "R",
+    map: (value) => (value === "s1" ? "r1" : "r2"),
+  }
+
+  registry.push(r, s, g, h)
+
+  it("detects mutually factoring monomorphisms", () => {
+    const witnesses = findMutualMonicFactorizations(category)
+    expect(witnesses).toHaveLength(1)
+    const [witness] = witnesses
+    expect(category.eq(category.compose(s, witness.forward), witness.left)).toBe(true)
+    expect(category.eq(category.compose(r, witness.backward), witness.right)).toBe(true)
+  })
+
+  it("verifies that the connecting arrows are inverse", () => {
+    const check = verifyMutualMonicFactorizations(category)
+    expect(check.holds).toBe(true)
+  })
+
+  it("oracle reports success", () => {
+    const result = MonicFactorizationYieldsIso.check(category)
+    expect(result.holds).toBe(true)
+  })
+})

--- a/test/mono-epi-not-iso.spec.ts
+++ b/test/mono-epi-not-iso.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { isEpi, isMono } from "../kinds/mono-epi"
+import { isIso } from "../kinds/iso"
+import { leftInverses } from "../kinds/inverses"
+import { TwoObjectCategory, nonIdentity } from "../two-object-cat"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import { FinGrpCat, type Hom } from "../models/fingroup-cat"
+
+describe("Mono + epi need not imply iso", () => {
+  const f = nonIdentity
+
+  it("has cancellable but non-invertible arrow in the two-object category", () => {
+    expect(isMono(TwoObjectCategory, f)).toBe(true)
+    expect(isEpi(TwoObjectCategory, f)).toBe(true)
+    expect(isIso(TwoObjectCategory, f)).toBe(false)
+  })
+
+  it("still validates iso ⇒ mono & epi in FinSet", () => {
+    const universe = { A: ["a1", "a2"], B: ["b1", "b2"] } as const
+    const category = FinSetCat(universe)
+    const iso: FuncArr = {
+      name: "iso",
+      dom: "A",
+      cod: "B",
+      map: (value) => (value === "a1" ? "b1" : "b2"),
+    }
+    ;(category.arrows as FuncArr[]).push(iso)
+    expect(isIso(category, iso)).toBe(true)
+    expect(isMono(category, iso)).toBe(true)
+    expect(isEpi(category, iso)).toBe(true)
+  })
+})
+
+describe("Grp counterexample: injective hom without a splitting", () => {
+  const Z2 = {
+    name: "Z2",
+    elems: ["0", "1"] as const,
+    e: "0",
+    mul: (a: string, b: string) => ((Number(a) + Number(b)) % 2).toString(),
+    inv: (a: string) => a,
+  }
+
+  const Z4 = {
+    name: "Z4",
+    elems: ["0", "1", "2", "3"] as const,
+    e: "0",
+    mul: (a: string, b: string) => ((Number(a) + Number(b)) % 4).toString(),
+    inv: (a: string) => ((4 - Number(a)) % 4).toString(),
+  }
+
+  const category = FinGrpCat([Z2, Z4])
+
+  const inclusion: Hom = {
+    name: "i",
+    dom: "Z2",
+    cod: "Z4",
+    map: (value) => (value === "0" ? "0" : "2"),
+  }
+
+  ;(category.arrows as Hom[]).push(inclusion)
+
+  it("is a monomorphism", () => {
+    expect(isMono(category, inclusion)).toBe(true)
+  })
+
+  it("admits no retraction", () => {
+    expect(leftInverses(category, inclusion)).toHaveLength(0)
+  })
+})

--- a/test/operations-rewriter.spec.ts
+++ b/test/operations-rewriter.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import { FinSetCat, type FuncArr } from "../models/finset-cat"
+import { Rewriter, defaultOperationRules } from "../operations/rewriter"
+
+describe("Operations layer rewrites", () => {
+  const universe = {
+    A: ["a1", "a2"],
+    B: ["b1", "b2"],
+    R: ["r1", "r2"],
+    S: ["s1", "s2"],
+    X: ["x1", "x2"],
+  } as const
+
+  const category = FinSetCat(universe)
+  const registry = category.arrows as FuncArr[]
+
+  const u: FuncArr = {
+    name: "u",
+    dom: "A",
+    cod: "B",
+    map: (value) => (value === "a1" ? "b2" : "b1"),
+  }
+  const v: FuncArr = {
+    name: "v",
+    dom: "B",
+    cod: "A",
+    map: (value) => (value === "b1" ? "a2" : "a1"),
+  }
+
+  const r: FuncArr = {
+    name: "r",
+    dom: "R",
+    cod: "X",
+    map: (value) => (value === "r1" ? "x1" : "x2"),
+  }
+  const s: FuncArr = {
+    name: "s",
+    dom: "S",
+    cod: "X",
+    map: (value) => (value === "s1" ? "x1" : "x2"),
+  }
+  const g: FuncArr = {
+    name: "g",
+    dom: "R",
+    cod: "S",
+    map: (value) => (value === "r1" ? "s1" : "s2"),
+  }
+  const h: FuncArr = {
+    name: "h",
+    dom: "S",
+    cod: "R",
+    map: (value) => (value === "s1" ? "r1" : "r2"),
+  }
+
+  registry.push(u, v, r, s, g, h)
+
+  const [isoRule, upgradeRule, balancedRule, epiMonoRule, objectIsoRule, mergeRule] =
+    defaultOperationRules<string, FuncArr>()
+
+  it("suggests cancelling inverse pairs", () => {
+    const rewriter = new Rewriter([isoRule])
+    const suggestions = rewriter.analyze({ category, path: [u, v, u] })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.severity).toBe("safe")
+    expect(suggestion.rewrites[0]?.kind).toBe("NormalizeComposite")
+  })
+
+  it("proposes upgrading monic arrows with right inverses", () => {
+    const rewriter = new Rewriter([upgradeRule])
+    const suggestions = rewriter.analyze({ category, focus: u })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.rewrites.some((rewrite) => rewrite.kind === "UpgradeToIso")).toBe(true)
+  })
+
+  it("promotes monic and epic arrows when the category is balanced", () => {
+    const rewriter = new Rewriter([balancedRule])
+    const suggestions = rewriter.analyze({ category, focus: u })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.oracle).toBe("BalancedMonoEpicIsIso")
+    expect(suggestion.rewrites.some((rewrite) => rewrite.kind === "UpgradeToIso")).toBe(true)
+  })
+
+  it("merges mutually factoring monomorphisms", () => {
+    const rewriter = new Rewriter([mergeRule])
+    const suggestions = rewriter.analyze({ category })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.rewrites.every((rewrite) => rewrite.kind === "MergeSubobjects")).toBe(true)
+  })
+
+  it("detects isomorphic objects and proposes a merge", () => {
+    const rewriter = new Rewriter([objectIsoRule])
+    const suggestions = rewriter.analyze({ category })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.rewrites.every((rewrite) => rewrite.kind === "MergeObjects")).toBe(true)
+  })
+
+  it("exposes epi-mono factorisations when focused on an arrow", () => {
+    const rewriter = new Rewriter([epiMonoRule])
+    const suggestions = rewriter.analyze({ category, focus: r })
+    expect(suggestions).toHaveLength(1)
+    const [suggestion] = suggestions
+    expect(suggestion.oracle).toBe("EpiMonoFactorization")
+    expect(suggestion.rewrites).toEqual([
+      {
+        kind: "FactorThroughEpiMono",
+        arrow: r,
+        epi: g,
+        mono: s,
+      },
+    ])
+  })
+})

--- a/test/pos-mono-epi.spec.ts
+++ b/test/pos-mono-epi.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { FinPosCat, FinPos, type MonoMap } from "../models/finpos-cat"
+import { isMono, isEpi } from "../kinds/mono-epi"
+
+describe("Finite Pos: mono⇔injective, epi⇔surjective", () => {
+  const A = {
+    name: "A",
+    elems: ["a1", "a2"] as const,
+    leq: (x: string, y: string) => x === y || x === "a1",
+  }
+  const B = {
+    name: "B",
+    elems: ["b1", "b2", "b3"] as const,
+    leq: (x: string, y: string) => x === y || x === "b1",
+  }
+  const category = FinPosCat([A, B, FinPos.one()])
+
+  const inj: MonoMap = { name: "i", dom: "A", cod: "B", map: (x) => (x === "a1" ? "b1" : "b2") }
+  const nonInj: MonoMap = { name: "n", dom: "A", cod: "B", map: (_x: string) => "b1" }
+  const surj: MonoMap = {
+    name: "s",
+    dom: "B",
+    cod: "A",
+    map: (y) => (y === "b3" ? "a2" : "a1"),
+  }
+  const nonSurj: MonoMap = { name: "t", dom: "B", cod: "A", map: (_x: string) => "a1" }
+
+  ;(category.arrows as MonoMap[]).push(inj, nonInj, surj, nonSurj)
+
+  it("monotone sanity", () => {
+    expect(FinPos.isMonotone(A, B, inj)).toBe(true)
+    expect(FinPos.isMonotone(A, B, nonInj)).toBe(true)
+    expect(FinPos.isMonotone(B, A, surj)).toBe(true)
+    expect(FinPos.isMonotone(B, A, nonSurj)).toBe(true)
+  })
+
+  it("monos correspond to injective monotone maps", () => {
+    expect(isMono(category, inj)).toBe(true)
+    expect(isMono(category, nonInj)).toBe(false)
+    expect(isMono(category, inj)).toBe(FinPos.injective(A, B, inj))
+    expect(isMono(category, nonInj)).toBe(FinPos.injective(A, B, nonInj))
+  })
+
+  it("epis correspond to surjective monotone maps", () => {
+    expect(isEpi(category, surj)).toBe(true)
+    expect(isEpi(category, nonSurj)).toBe(false)
+    expect(isEpi(category, surj)).toBe(FinPos.surjective(B, A, surj))
+    expect(isEpi(category, nonSurj)).toBe(FinPos.surjective(B, A, nonSurj))
+  })
+})

--- a/test/pushout-fixture.ts
+++ b/test/pushout-fixture.ts
@@ -1,0 +1,70 @@
+import type { FiniteCategory } from "../finite-cat"
+
+type Obj = "X" | "Z" | "A" | "B" | "Qf" | "Qg"
+
+type Arrow = {
+  readonly name: string
+  readonly src: Obj
+  readonly dst: Obj
+}
+
+const objects: readonly Obj[] = ["X", "Z", "A", "B", "Qf", "Qg"]
+
+const arrowByName = new Map<string, Arrow>()
+const makeArrow = (name: string, src: Obj, dst: Obj): Arrow => {
+  const arrow = { name, src, dst } as const
+  arrowByName.set(name, arrow)
+  return arrow
+}
+
+const arrows: readonly Arrow[] = [
+  ...objects.map((object) => makeArrow(`id_${object}`, object, object)),
+  makeArrow("f", "X", "A"),
+  makeArrow("g", "X", "B"),
+  makeArrow("h", "X", "Z"),
+  makeArrow("j", "A", "B"),
+  makeArrow("qAf", "A", "Qf"),
+  makeArrow("qZf", "Z", "Qf"),
+  makeArrow("liftF", "X", "Qf"),
+  makeArrow("qBg", "B", "Qg"),
+  makeArrow("qZg", "Z", "Qg"),
+  makeArrow("liftG", "X", "Qg"),
+  makeArrow("qBgJ", "A", "Qg"),
+  makeArrow("u", "Qf", "Qg"),
+]
+
+export const getArrow = (name: string): Arrow => {
+  const arrow = arrowByName.get(name)
+  if (!arrow) throw new Error(`unknown arrow ${name}`)
+  return arrow
+}
+
+const compose = (g: Arrow, f: Arrow): Arrow => {
+  if (f.dst !== g.src) throw new Error(`compose mismatch for ${g.name} ∘ ${f.name}`)
+  if (f.name.startsWith("id_")) return getArrow(g.name)
+  if (g.name.startsWith("id_")) return getArrow(f.name)
+  if (f.name === "f" && g.name === "j") return getArrow("g")
+  if (f.name === "f" && g.name === "qAf") return getArrow("liftF")
+  if (f.name === "h" && g.name === "qZf") return getArrow("liftF")
+  if (f.name === "g" && g.name === "qBg") return getArrow("liftG")
+  if (f.name === "h" && g.name === "qZg") return getArrow("liftG")
+  if (f.name === "qAf" && g.name === "u") return getArrow("qBgJ")
+  if (f.name === "j" && g.name === "qBg") return getArrow("qBgJ")
+  if (f.name === "f" && g.name === "qBgJ") return getArrow("liftG")
+  if (f.name === "qZf" && g.name === "u") return getArrow("qZg")
+  if (f.name === "liftF" && g.name === "u") return getArrow("liftG")
+  throw new Error(`unsupported composition ${g.name} ∘ ${f.name}`)
+}
+
+export const PushoutCategory: FiniteCategory<Obj, Arrow> = {
+  objects,
+  arrows,
+  id: (object) => getArrow(`id_${object}`),
+  compose,
+  src: (arrow) => arrow.src,
+  dst: (arrow) => arrow.dst,
+  eq: (a, b) => a.name === b.name,
+}
+
+export type PushoutObj = Obj
+export type PushoutArrow = Arrow

--- a/traits/global-elements.ts
+++ b/traits/global-elements.ts
@@ -1,0 +1,30 @@
+import type { FiniteCategory } from "../finite-cat"
+
+export interface HasTerminal<Obj, Arr> {
+  readonly one: () => Obj
+  readonly globals: (object: Obj) => ReadonlyArray<Arr>
+}
+
+/**
+ * Decide monicity by probing arrows with global elements (maps from the
+ * terminal object). Whenever two elements agree after composing with the
+ * arrow, they must already be equal.
+ */
+export const isMonoByGlobals = <Obj, Arr>(
+  category: FiniteCategory<Obj, Arr> & HasTerminal<Obj, Arr>,
+  f: Arr,
+): boolean => {
+  const terminal = category.one()
+  const domain = category.src(f)
+  const elements = category.globals(domain).filter((el) => category.src(el) === terminal)
+  for (const x of elements) {
+    for (const y of elements) {
+      const fx = category.compose(f, x)
+      const fy = category.compose(f, y)
+      if (category.eq(fx, fy) && !category.eq(x, y)) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/two-object-cat.ts
+++ b/two-object-cat.ts
@@ -1,0 +1,39 @@
+import type { FiniteCategory } from "./finite-cat"
+
+export type TwoObject = "•" | "★"
+
+export interface TwoArrow {
+  readonly name: string
+  readonly src: TwoObject
+  readonly dst: TwoObject
+}
+
+const id = (object: TwoObject): TwoArrow => ({ name: `id_${object}`, src: object, dst: object })
+
+const idDot = id("•")
+const idStar = id("★")
+
+const f: TwoArrow = { name: "f", src: "•", dst: "★" }
+
+const arrows: readonly TwoArrow[] = [idDot, idStar, f]
+
+const compose = (g: TwoArrow, h: TwoArrow): TwoArrow => {
+  if (h.dst !== g.src) {
+    throw new Error("TwoObjectCategory: non-composable arrows")
+  }
+  if (h.name.startsWith("id_")) return g
+  if (g.name.startsWith("id_")) return h
+  throw new Error("TwoObjectCategory: no non-identity composites")
+}
+
+export const TwoObjectCategory: FiniteCategory<TwoObject, TwoArrow> = {
+  objects: ["•", "★"],
+  arrows,
+  id,
+  compose,
+  src: (arrow) => arrow.src,
+  dst: (arrow) => arrow.dst,
+  eq: (x, y) => x.name === y.name && x.src === y.src && x.dst === y.dst,
+}
+
+export const nonIdentity = f


### PR DESCRIPTION
## Summary
- generalize the finite group adapter so its elements can be used across groupoid utilities and exported through the barrel
- add a helper that reconstructs the underlying group from a one-object groupoid and document the group↔groupoid round trip
- extend the groupoid tests to exercise the new conversion in addition to the existing action groupoid scenario

## Testing
- npm run typecheck
- npx vitest run test/kinds/groupoid.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d773d975c48326951feac2ff4b7fa5