### PR TITLE
Tighten categorical tests for strict typechecking

### DIFF
--- a/bss-simple.ts
+++ b/bss-simple.ts
@@ -11,7 +11,11 @@ export type StandardMeasure<Θ> = Dist<number, Posterior<Θ>>;
  * Enhanced BSS compare with simple dilation search
  * Tests identity, uniform spread, and simple convex combinations
  */
-export function bssCompare<Θ extends string | number, X, Y>(
+export function bssCompare<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,
@@ -66,7 +70,11 @@ export function bssCompare<Θ extends string | number, X, Y>(
 /**
  * Test BSS equivalence with detailed reporting
  */
-export function testBSSDetailed<Θ extends string | number, X, Y>(
+export function testBSSDetailed<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,
@@ -105,7 +113,11 @@ export function testBSSDetailed<Θ extends string | number, X, Y>(
 /**
  * Analyze BSS relationship with standard measure details
  */
-export function analyzeBSS<Θ extends string | number, X, Y>(
+export function analyzeBSS<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,

--- a/bss.ts
+++ b/bss.ts
@@ -191,7 +191,11 @@ export type StandardMeasure<Θ> = Dist<number, Posterior<Θ>>;
  * Enhanced BSS compare with barycentric dilation search
  * f ⪰ g iff ∃ dilation T with gHat = T# fHat and e∘T = id
  */
-export function bssCompare<Θ extends string | number, X, Y>(
+export function bssCompare<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,
@@ -218,7 +222,11 @@ export function bssCompare<Θ extends string | number, X, Y>(
 /**
  * Test BSS equivalence with detailed dilation analysis
  */
-export function testBSSDetailed<Θ extends string | number, X, Y>(
+export function testBSSDetailed<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,
@@ -257,7 +265,11 @@ export function testBSSDetailed<Θ extends string | number, X, Y>(
 /**
  * Comprehensive BSS analysis with dilation search details
  */
-export function analyzeBSS<Θ extends string | number, X, Y>(
+export function analyzeBSS<
+  Θ extends string | number,
+  X extends string | number,
+  Y extends string | number
+>(
   m: Dist<number, Θ>,
   f: (θ: Θ) => Dist<number, X>,
   g: (θ: Θ) => Dist<number, Y>,
@@ -295,7 +307,10 @@ export function analyzeBSS<Θ extends string | number, X, Y>(
 /**
  * Batch test BSS relationships across multiple experiments
  */
-export function testBSSMatrix<Θ extends string | number, X>(
+export function testBSSMatrix<
+  Θ extends string | number,
+  X extends string | number
+>(
   m: Dist<number, Θ>,
   experiments: Array<{
     name: string;
@@ -344,7 +359,10 @@ export function testBSSMatrix<Θ extends string | number, X>(
 /**
  * Find the most informative experiment with dilation analysis
  */
-export function findMostInformative<Θ extends string | number, X>(
+export function findMostInformative<
+  Θ extends string | number,
+  X extends string | number
+>(
   m: Dist<number, Θ>,
   experiments: Array<{
     name: string;

--- a/examples/diagram-demo.ts
+++ b/examples/diagram-demo.ts
@@ -1,6 +1,5 @@
+import type { Arrow, Path } from "../diagram";
 import {
-  Arrow,
-  Path,
   allCommute,
   allCommuteTweaked,
   commutes,
@@ -21,8 +20,8 @@ const log = (label: string, value: unknown) => {
   const h: Arrow<number, number> = x => x * 2;
   const j: Arrow<number, number> = x => x - 3;
 
-  const left: Path<number, number> = [g, h, j];
-  const right: Path<number, number> = [g, (x: number) => j(h(x))];
+  const left = [g, h, j] as Path<number, number>;
+  const right = [g, (x: number) => j(h(x))] as Path<number, number>;
   const sample = [0, 1, 2, 5];
 
   log("triangle commutes?", commutes(left, right, sample));
@@ -51,16 +50,16 @@ const log = (label: string, value: unknown) => {
   const l: Arrow<number, number> = x => (x - 1) * 3; // C → E matches k ∘ h
 
   const squareLeft: Path<number, number>[] = [
-    [f, g],
-    [j],
+    [f, g] as Path<number, number>,
+    [j] as Path<number, number>,
   ];
   const squareRight: Path<number, number>[] = [
-    [h, k],
-    [l],
+    [h, k] as Path<number, number>,
+    [l] as Path<number, number>,
   ];
 
-  const rect1 = paste(squareLeft[0], squareRight[0]);
-  const rect2 = paste(squareLeft[1], squareRight[1]);
+  const rect1 = paste(squareLeft[0]!, squareRight[0]!);
+  const rect2 = paste(squareLeft[1]!, squareRight[1]!);
   const sample = [0, 3];
 
   log("left square commutes?", allCommute(squareLeft, sample));
@@ -76,11 +75,25 @@ const log = (label: string, value: unknown) => {
   const sampleE = [0, 1, 2];
   const sampleA = [3, 4];
 
-  log("parallel arrows allowed", commutesTweaked([f], [g], sampleA));
-  log("fork commutes", commutesTweaked([f, e], [g, e], sampleE));
+  log(
+    "parallel arrows allowed",
+    commutesTweaked([f] as Path<number, number>, [g] as Path<number, number>, sampleA)
+  );
+  log(
+    "fork commutes",
+    commutesTweaked(
+      [f, e] as Path<number, number>,
+      [g, e] as Path<number, number>,
+      sampleE
+    )
+  );
   log(
     "detects non-commuting",
-    !commutesTweaked([f, () => 2], [g, e], sampleE)
+    !commutesTweaked(
+      [f, () => 2] as Path<number, number>,
+      [g, e] as Path<number, number>,
+      sampleE
+    )
   );
 }
 
@@ -94,10 +107,10 @@ const log = (label: string, value: unknown) => {
     "family commutes (tweaked)",
     allCommuteTweaked(
       [
-        [f],
-        [g],
-        [f, e],
-        [g, e],
+        [f] as Path<number, number>,
+        [g] as Path<number, number>,
+        [f, e] as Path<number, number>,
+        [g, e] as Path<number, number>,
       ],
       [0, 1, 2]
     )

--- a/experiments.ts
+++ b/experiments.ts
@@ -1,5 +1,7 @@
 // experiments.ts — families of measures + priors + risks
-import { Fin, Kernel, Dist, normalize } from "./markov-category";
+import type { Fin, Kernel } from "./markov-category";
+import { normalize } from "./markov-category";
+import type { LegacyDist as Dist } from "./dist";
 
 export type Experiment<Theta, Obs> = Kernel<Theta, Obs>;
 export type PosteriorSupport<Theta> = { post: Dist<Theta>, weight: number };  // Blackwell support point-list

--- a/freecat.ts
+++ b/freecat.ts
@@ -1,4 +1,4 @@
-import { DiGraph, NodeId } from './graph';
+import type { DiGraph, NodeId } from './graph';
 
 export interface Path {
   readonly src: NodeId;

--- a/hmm-viterbi.ts
+++ b/hmm-viterbi.ts
@@ -3,7 +3,8 @@
 //
 // Depends on: markov-category.ts, semiring-dist.ts, semiring-utils.ts
 //
-import { Fin, Kernel, Dist } from "./markov-category";
+import type { Fin, Kernel } from "./markov-category";
+import type { LegacyDist as Dist } from "./dist";
 import { TropicalMaxPlus, LogProb, RPlus, normalizeR } from "./semiring-dist";
 import { fromScoresMax, fromLogits, fromProbs, argBestR } from "./semiring-utils";
 

--- a/markov-graded.ts
+++ b/markov-graded.ts
@@ -1,7 +1,11 @@
 // markov-graded.ts
 import { Kernel, Dist, dirac, prune } from "./markov-category";
 
-export interface Monoid<G> { empty: G; concat: (a:G,b:G)=>G; equals?: (a:G,b:G>)=>boolean; }
+export interface Monoid<G> {
+  empty: G;
+  concat: (a: G, b: G) => G;
+  equals?: (a: G, b: G) => boolean;
+}
 export type GradedKernel<G,X,Y> = (x:X)=>{ dist: Dist<Y>; grade: G };
 
 export function gDeterministic<G,X,Y>(M:Monoid<G>, f:(x:X)=>Y, g:G): GradedKernel<G,X,Y> {

--- a/test/mon-cat.spec.ts
+++ b/test/mon-cat.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { MonCat, isMonoidHom } from "../mon-cat";
-import { Monoid } from "../monoid-cat";
+import type { Monoid } from "../monoid-cat";
 
 const BoolAnd: Monoid<boolean> = {
   e: true,

--- a/test/monic-factorization.spec.ts
+++ b/test/monic-factorization.spec.ts
@@ -46,7 +46,8 @@ describe("Monic factorisation oracles", () => {
   it("detects mutually factoring monomorphisms", () => {
     const witnesses = findMutualMonicFactorizations(category)
     expect(witnesses).toHaveLength(1)
-    const [witness] = witnesses
+    const witness = witnesses[0]
+    if (!witness) throw new Error("expected a mutual monic factorization witness")
     expect(category.eq(category.compose(s, witness.forward), witness.left)).toBe(true)
     expect(category.eq(category.compose(r, witness.backward), witness.right)).toBe(true)
   })

--- a/test/operations-rewriter.spec.ts
+++ b/test/operations-rewriter.spec.ts
@@ -57,11 +57,16 @@ describe("Operations layer rewrites", () => {
   const [isoRule, upgradeRule, balancedRule, epiMonoRule, objectIsoRule, mergeRule] =
     defaultOperationRules<string, FuncArr>()
 
+  if (!isoRule || !upgradeRule || !balancedRule || !epiMonoRule || !objectIsoRule || !mergeRule) {
+    throw new Error("defaultOperationRules must provide the expected six rules for the test fixtures")
+  }
+
   it("suggests cancelling inverse pairs", () => {
     const rewriter = new Rewriter([isoRule])
     const suggestions = rewriter.analyze({ category, path: [u, v, u] })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for inverse pair cancellation")
     expect(suggestion.severity).toBe("safe")
     expect(suggestion.rewrites[0]?.kind).toBe("NormalizeComposite")
   })
@@ -70,7 +75,8 @@ describe("Operations layer rewrites", () => {
     const rewriter = new Rewriter([upgradeRule])
     const suggestions = rewriter.analyze({ category, focus: u })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for upgrading monic arrows")
     expect(suggestion.rewrites.some((rewrite) => rewrite.kind === "UpgradeToIso")).toBe(true)
   })
 
@@ -78,7 +84,8 @@ describe("Operations layer rewrites", () => {
     const rewriter = new Rewriter([balancedRule])
     const suggestions = rewriter.analyze({ category, focus: u })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for balanced mono/epi upgrades")
     expect(suggestion.oracle).toBe("BalancedMonoEpicIsIso")
     expect(suggestion.rewrites.some((rewrite) => rewrite.kind === "UpgradeToIso")).toBe(true)
   })
@@ -87,7 +94,8 @@ describe("Operations layer rewrites", () => {
     const rewriter = new Rewriter([mergeRule])
     const suggestions = rewriter.analyze({ category })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for merging monomorphisms")
     expect(suggestion.rewrites.every((rewrite) => rewrite.kind === "MergeSubobjects")).toBe(true)
   })
 
@@ -95,7 +103,8 @@ describe("Operations layer rewrites", () => {
     const rewriter = new Rewriter([objectIsoRule])
     const suggestions = rewriter.analyze({ category })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for object merges")
     expect(suggestion.rewrites.every((rewrite) => rewrite.kind === "MergeObjects")).toBe(true)
   })
 
@@ -103,7 +112,8 @@ describe("Operations layer rewrites", () => {
     const rewriter = new Rewriter([epiMonoRule])
     const suggestions = rewriter.analyze({ category, focus: r })
     expect(suggestions).toHaveLength(1)
-    const [suggestion] = suggestions
+    const suggestion = suggestions[0]
+    if (!suggestion) throw new Error("expected a suggestion for epi-mono factorisation")
     expect(suggestion.oracle).toBe("EpiMonoFactorization")
     expect(suggestion.rewrites).toEqual([
       {

--- a/test/practical-utilities.spec.ts
+++ b/test/practical-utilities.spec.ts
@@ -2,13 +2,14 @@ import { describe, it, expect } from 'vitest'
 import {
   SemiringNat, SemiringMinPlus, SemiringMaxPlus, SemiringBoolOrAnd, SemiringProb,
   vecMat, matVec, powMat, closureUpTo,
-  WeightedAutomaton, waRun, waAcceptsBool,
-  HMM, hmmForward, diagFromVec, normalizeRow,
-  Edge, graphAdjNat, graphAdjBool, graphAdjWeights,
+  waRun, waAcceptsBool,
+  hmmForward, diagFromVec, normalizeRow,
+  graphAdjNat, graphAdjBool, graphAdjWeights,
   countPathsOfLength, reachableWithin, shortestPathsUpTo,
   transitiveClosureBool, compileRegexToWA,
   eye,
 } from '../allTS'
+import type { WeightedAutomaton, HMM, Edge } from '../allTS'
 
 describe('Practical Semirings', () => {
   it('MinPlus semiring works for shortest paths', () => {
@@ -82,10 +83,10 @@ describe('Weighted Automata', () => {
   it('counts paths in simple automaton', () => {
     const init = [1, 0] as const
     const final = [0, 1] as const
-    const delta = {
-      a: [[0,1],[0,0]],
-      b: [[0,0],[0,1]],
-    } as const
+    const delta: Record<'a' | 'b', number[][]> = {
+      a: [[0, 1], [0, 0]],
+      b: [[0, 0], [0, 1]]
+    }
     const WA: WeightedAutomaton<number, 'a'|'b'> = { 
       S: SemiringNat, n: 2, init, final, delta 
     }
@@ -98,10 +99,10 @@ describe('Weighted Automata', () => {
   it('accepts words with Boolean automaton', () => {
     const init = [true, false] as const
     const final = [false, true] as const
-    const delta = {
-      a: [[false,true],[false,false]], // from state 0: go to 1; from state 1: stuck
-      b: [[false,false],[false,true]], // from state 0: stuck; from state 1: stay
-    } as const
+    const delta: Record<'a' | 'b', boolean[][]> = {
+      a: [[false, true], [false, false]], // from state 0: go to 1; from state 1: stuck
+      b: [[false, false], [false, true]]  // from state 0: stuck; from state 1: stay
+    }
     const DFA: WeightedAutomaton<boolean, 'a'|'b'> = { 
       S: SemiringBoolOrAnd, n: 2, init, final, delta 
     }

--- a/test/preord-cat.spec.ts
+++ b/test/preord-cat.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { PreordCat, isMonotone } from "../preord-cat";
-import { Preorder } from "../preorder-cat";
+import type { Preorder } from "../preorder-cat";
 
 const naturalOrder: Preorder<number> = {
   elems: [0, 1, 2, 3],

--- a/test/pushforward-complete.spec.ts
+++ b/test/pushforward-complete.spec.ts
@@ -1,15 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import {
-  // Basic types
   FinSet,
-  FinSetObj,
-  FinSetMor,
-  // Categorical structures
-  CatFunctor,
-  CatNatTrans,
-  CatMonad,
-  Adjunction,
-  // Operations
   composeFun,
   idFun,
   whiskerLeft,
@@ -21,13 +12,21 @@ import {
   pushforwardMonad,
   colaxAlongLeftAdjoint,
   pushforwardAlgebra,
-  // Examples
   freeVectFunctor,
   forgetVectFunctor,
   freeForgetfulAdjunction,
   listMonadFinSet,
-  // Enhanced Vect
   EnhancedVect
+} from '../allTS'
+import type {
+  FinSetObj,
+  FinSetMor,
+  CatFunctor,
+  CatNatTrans,
+  CatMonad,
+  Adjunction,
+  CatId,
+  CatCompose
 } from '../allTS'
 
 describe('Complete Pushforward Monad Implementation', () => {

--- a/test/pushforward-monad.spec.ts
+++ b/test/pushforward-monad.spec.ts
@@ -1,32 +1,28 @@
 import { describe, test, expect } from 'vitest'
 import {
-  // Basic types
+  // Basic structures
   FinSet,
-  FinSetObj,
-  FinSetMor,
-  // Categorical structures
-  CatFunctor,
-  CatNatTrans,
-  CatIdentity,
-  CatCompose,
-  CategoricalMonad,
-  Adjunction,
   // Operations
   composeFun,
   idFun,
   whiskerLeft,
   whiskerRight,
-  vcomp,
-  hcomp,
-  unitMate,
-  counitMate,
   pushforwardMonad
+} from '../allTS'
+import type {
+  FinSetObj,
+  CatFunctor,
+  CatNatTrans,
+  CatId,
+  CatCompose,
+  CatMonad,
+  Adjunction
 } from '../allTS'
 
 describe('Pushforward monads', () => {
   test('can construct basic categorical structures', () => {
     // Create a simple identity functor
-    const idFinSet: CatIdentity<typeof FinSet> = {
+    const idFinSet: CatId<typeof FinSet> = {
       source: FinSet,
       target: FinSet,
       onObj: (obj: any) => obj,
@@ -84,13 +80,13 @@ describe('Pushforward monads', () => {
     }
 
     // Mock natural transformations for adjunction
-    const unit: CatNatTrans<CatIdentity<typeof C>, CatCompose<typeof U, typeof F>> = {
+    const unit: CatNatTrans<CatId<typeof C>, CatCompose<typeof U, typeof F>> = {
       source: idFun(C),
       target: composeFun(U, F),
       component: (x: any) => `η(${x})`
     }
 
-    const counit: CatNatTrans<CatCompose<typeof F, typeof U>, CatIdentity<typeof D>> = {
+    const counit: CatNatTrans<CatCompose<typeof F, typeof U>, CatId<typeof D>> = {
       source: composeFun(F, U),
       target: idFun(D),
       component: (x: any) => `ε(${x})`
@@ -101,7 +97,7 @@ describe('Pushforward monads', () => {
     }
 
     // Mock monad on C
-    const T: CategoricalMonad<typeof C> = {
+    const T: CatMonad<typeof C> = {
       category: C,
       endofunctor: {
         source: C,

--- a/test/rational-field.spec.ts
+++ b/test/rational-field.spec.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import {
-  Q, FieldQ, FieldReal, Qof, Qeq, Qadd, Qneg, Qsub, Qmul, Qinv, Qdiv, QfromInt, QfromRatio, QtoString,
+  FieldQ, FieldReal, Qof, Qeq, Qadd, Qneg, Qsub, Qmul, Qinv, Qdiv, QfromInt, QfromRatio, QtoString,
   rref, nullspace, colspace, solveLinear, rrefQPivot, qAbsCmp, isQZero,
   runLesConeProps, randomTwoTermComplex, makeHomologyShiftIso,
   imageComplex, coimageComplex, coimToIm, isIsoChainMap, smoke_coim_im_iso,
   idChainMapN, zeroChainMapN,
 } from '../allTS'
+import type { Q } from '../allTS'
+
+const requireEq = <R>(eq: ((x: R, y: R) => boolean) | undefined) => {
+  if (!eq) {
+    throw new Error('Expected field equality predicate to be available')
+  }
+  return eq
+}
 
 describe('Rational field Q', () => {
   it('creates and normalizes rationals correctly', () => {
@@ -59,8 +67,9 @@ describe('Rational field Q', () => {
     expect(one.den).toBe(1n)
     
     const a = Qof(5, 7)
-    expect(F.eq(F.add(a, zero), a)).toBe(true)
-    expect(F.eq(F.mul(a, one), a)).toBe(true)
+    const eq = requireEq(F.eq)
+    expect(eq(F.add(a, zero), a)).toBe(true)
+    expect(eq(F.mul(a, one), a)).toBe(true)
   })
 
   it('pretty prints rationals', () => {
@@ -126,8 +135,9 @@ describe('Linear algebra over rationals', () => {
     const check0 = F.add(F.mul(A[0]![0]!, x[0]!), F.mul(A[0]![1]!, x[1]!))
     const check1 = F.add(F.mul(A[1]![0]!, x[0]!), F.mul(A[1]![1]!, x[1]!))
     
-    expect(F.eq(check0, b[0]!)).toBe(true)
-    expect(F.eq(check1, b[1]!)).toBe(true)
+    const eq = requireEq(F.eq)
+    expect(eq(check0, b[0]!)).toBe(true)
+    expect(eq(check1, b[1]!)).toBe(true)
   })
 })
 

--- a/test/subcategory.spec.ts
+++ b/test/subcategory.spec.ts
@@ -57,8 +57,13 @@ const parent: SmallCategory<Obj, Arr> = {
 };
 
 describe("subcategory saturation", () => {
+  const objectsABC: readonly Obj[] = ["A", "B", "C"]
+  const objectsAB: readonly Obj[] = ["A", "B"]
+  const arrowsFG: readonly Arr[] = [f, g]
+  const arrowsF: readonly Arr[] = [f]
+
   it("adds identities and stays closed under composition", () => {
-    const S = makeSubcategory(parent, ["A", "B", "C"], [f, g]);
+    const S = makeSubcategory(parent, objectsABC, arrowsFG);
     expect(S.arrows.has(f)).toBe(true);
     expect(S.arrows.has(g)).toBe(true);
     expect(S.arrows.has(h)).toBe(true);
@@ -68,7 +73,7 @@ describe("subcategory saturation", () => {
   });
 
   it("builds a full subcategory on chosen objects", () => {
-    const full = makeFullSubcategory(parent, ["A", "B"]);
+    const full = makeFullSubcategory(parent, objectsAB);
     expect(full.arrows.has(f)).toBe(true);
     expect(full.arrows.has(idA)).toBe(true);
     expect(full.arrows.has(idB)).toBe(true);
@@ -77,7 +82,7 @@ describe("subcategory saturation", () => {
   });
 
   it("detects non-full subcategories", () => {
-    const nonFull = makeSubcategory(parent, ["A", "B"], [f]);
+    const nonFull = makeSubcategory(parent, objectsAB, arrowsF);
     expect(isFullSubcategory(nonFull, parent)).toBe(false);
   });
 });

--- a/test/triangulated.spec.ts
+++ b/test/triangulated.spec.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
-  RingReal, Complex, ChainMap, Triangle,
+  RingReal,
   complexIsValid, isChainMap, shift1, cone, triangleFromMap, triangleIsSane,
   matAdd, matNeg, zerosMat, idMat, hcat, vcat,
 } from '../allTS'
+import type { Complex, ChainMap, Triangle } from '../allTS'
 
 describe('Ring operations', () => {
   it('RingReal implements ring operations correctly', () => {

--- a/test/two-cat.registry-and-laws.spec.ts
+++ b/test/two-cat.registry-and-laws.spec.ts
@@ -1,26 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import fc from 'fast-check'
 import {
-  // core
-  EndofunctorK1, SimpleApplicativeK1, TraversableK1,
   // functors & data
   Some, None, Ok, Err, isOk, isSome, mapO, mapR,
   EitherEndo, ResultK1,
-  PairEndo, Pair,
-  SumEndo, inL, inR, SumVal,
-  ProdEndo, prod, ProdVal,
+  PairEndo,
+  SumEndo, inL, inR,
+  ProdEndo, prod,
   TraversableArrayK1, PromiseApp,
   // new registry glue
   makeTraversableRegistryK1,
-  TraversableOptionK1, TraversableEitherK1, TraversableNEAK1,
+  TraversableOptionK1, TraversableEitherK1,
   TraversablePairK1, TraversableConstK1,
   deriveTraversableSumK1, deriveTraversableProdK1, deriveTraversableCompK1,
   registerEitherTraversable, registerPairTraversable, registerConstTraversable,
   registerSumDerived, registerProdDerived, registerCompDerived,
-  distributePromiseK1, makePostcomposePromise2WithRegistry,
+  distributePromiseK1,
   // alignment
-  buildNatForTerms, BaseT, SumT, ProdT, EndoDict, idNatK1,
+  buildNatForTerms, BaseT, SumT, ProdT, idNatK1,
   EndoTermAlignError
+} from '../allTS'
+import type {
+  EndofunctorK1,
+  SimpleApplicativeK1,
+  EndoDict
 } from '../allTS'
 
 // util: JSON equality

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "resolvePackageJsonExports": true,
+    "types": ["node", "vitest"]
+  },
   "include": ["**/*.ts", "eslint-plugin-tinyfp/**/*.js"]
 }


### PR DESCRIPTION
## Summary
- guard the default operation rules fixtures so the rewrites suite works with strict undefined checks
- ensure monic factorization tests validate retrieved witnesses explicitly and treat monoid imports as type-only
- reuse typed seed collections and actual adjunction functors in subcategory and pushforward specs to satisfy stricter functor typings

## Testing
- `npx tsc --project tsconfig.eslint.json --noEmit --pretty false` *(fails: outstanding legacy Markov and mixed distributive law suites still violate strict typing)*

------
https://chatgpt.com/codex/tasks/task_e_68d85e088268832683c218173aeea63f