### PR TITLE
feat(ui): theme persistence and minor a11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FP-3 Playground</title>
+    <script>
+      const t = localStorage.getItem('theme');
+      if (t === 'dark') document.documentElement.classList.add('dark');
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'theme';
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+  return window.localStorage.getItem(THEME_STORAGE_KEY) === 'dark' ? 'dark' : 'light';
+};
+
+const persistTheme = (theme: Theme) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+};
+
+const syncDocumentTheme = (theme: Theme) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+};
+
+const themeLabel = (theme: Theme) => (theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+
+export const App = () => {
+  const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
+
+  useEffect(() => {
+    syncDocumentTheme(theme);
+    persistTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const buttonLabel = useMemo(() => themeLabel(theme), [theme]);
+
+  return (
+    <div className="app" tabIndex={0}>
+      <header>
+        <h1>FP-3 Playground</h1>
+      </header>
+      <main>
+        <button type="button" aria-label="Toggle theme" onClick={toggleTheme}>
+          {buttonLabel}
+        </button>
+      </main>
+    </div>
+  );
+};
+
+export default App;


### PR DESCRIPTION
## Summary
- persist previously selected theme on initial page load by reading localStorage and applying the dark class before hydration
- make the app root focusable and keep the theme toggle accessible with a stable label

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dde6359d8483268c9edd4a21a7165f