### PR TITLE
Add precomposition oracle and tighten resolution checks

### DIFF
--- a/relative/relative-laws.ts
+++ b/relative/relative-laws.ts
@@ -85,6 +85,12 @@ export const RelativeAdjunctionLawRegistry = {
     summary:
       "The chosen 2-cells witnessing C(ℓ-, -) ≅ E(j-, r-) must have matching frames and reuse ℓ and r as their vertical boundaries, mirroring Definition 5.1.",
   },
+  precomposition: {
+    name: "Relative adjunction tight precomposition",
+    registryPath: "relativeAdjunction.precomposition.tight",
+    summary:
+      "Proposition 5.29 transports j-relative adjunctions along tight cells u : A' → A by forming (ℓ ∘ u ⊣_{j ∘ u} r); the oracle checks the shared domain required for this precomposition.",
+  },
   unitCounit: {
     name: "Relative adjunction unit/counit presentation",
     registryPath: "relativeAdjunction.unitCounit.presentation",

--- a/test/relative/relative-monads.spec.ts
+++ b/test/relative/relative-monads.spec.ts
@@ -10,11 +10,13 @@ import {
   analyzeRelativeMonadFraming,
   analyzeRelativeMonadIdentityReduction,
   analyzeRelativeMonadRepresentability,
+  analyzeRelativeMonadResolution,
   analyzeRelativeMonadSkewMonoidBridge,
   describeTrivialRelativeMonad,
   type RelativeMonadData,
   type RelativeMonadSkewMonoidBridgeInput,
 } from "../../relative/relative-monads";
+import { describeTrivialRelativeAdjunction } from "../../relative/relative-adjunctions";
 import {
   RelativeMonadOracles,
   enumerateRelativeMonadOracles,
@@ -154,6 +156,36 @@ describe("Relative monad identity reduction", () => {
     expect(report.holds).toBe(false);
     expect(report.issues).toContain(
       "Root j and carrier t must coincide to model an ordinary monad.",
+    );
+  });
+});
+
+describe("Relative monad resolution analyzer", () => {
+  it("recognises the trivial resolution", () => {
+    const { equipment, trivial } = makeTrivialData();
+    const adjunction = describeTrivialRelativeAdjunction(equipment, "•");
+    const report = analyzeRelativeMonadResolution({ monad: trivial, adjunction });
+    expect(report.holds).toBe(true);
+    expect(report.looseMonad.holds).toBe(true);
+    expect(report.looseMonad.induced).toBe(trivial.looseCell);
+    expect(report.issues).toHaveLength(0);
+  });
+
+  it("detects mismatched carriers", () => {
+    const { equipment, trivial } = makeTrivialData();
+    const adjunction = describeTrivialRelativeAdjunction(equipment, "•");
+    const mismatched = {
+      ...trivial,
+      carrier: identityVerticalBoundary(
+        equipment,
+        "★",
+        "Mismatched carrier to violate the resolution conditions.",
+      ),
+    } as typeof trivial;
+    const report = analyzeRelativeMonadResolution({ monad: mismatched, adjunction });
+    expect(report.holds).toBe(false);
+    expect(report.issues).toContain(
+      "Relative monad carrier should match the right leg r.",
     );
   });
 });


### PR DESCRIPTION
## Summary
- add a relative adjunction precomposition analyzer/oracle capturing Proposition 5.29
- reinforce relative adjunction resolution by identifying the induced loose monad from Corollary 5.28
- extend adjunction and monad test suites to cover the new analyzer, oracle, and loose-arrow witness checks

## Testing
- `npm run typecheck` *(fails: missing vitest dependency in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f4e9c6408326aaf354567dd490ab