### PR TITLE
Fix traversable law typing and add vitest stubs

### DIFF
--- a/test/groupoid-kan-action.spec.ts
+++ b/test/groupoid-kan-action.spec.ts
@@ -24,9 +24,9 @@ describe('Groupoid Kan with automorphism quotient (FinSet)', () => {
     const H1: FiniteGroupoid<'h', { from: 'h'; to: 'h'; tag: 'id' | 'tau' }> = {
       objects: ['h'],
       id: (_h) => ({ from: 'h', to: 'h', tag: 'id' }),
-      compose: (g, f) => ({ 
-        from: 'h', 
-        to: 'h', 
+      compose: (g, f) => ({
+        from: 'h',
+        to: 'h',
         tag: (f.tag === 'tau') !== (g.tag === 'tau') ? 'tau' : 'id' 
       }),
       dom: (m) => m.from,
@@ -42,10 +42,15 @@ describe('Groupoid Kan with automorphism quotient (FinSet)', () => {
     // G: same structure
     const G1: typeof H1 = H1
 
-    const u: GFunctor<'h', any, 'h', any> = {
-      source: G1 as any, 
-      target: H1 as any,
-      onObj: (_g) => 'h',
+    type Obj = (typeof G1)['objects'][number]
+    type Mor = ReturnType<typeof G1['id']>
+
+    const fixedObj: Obj = G1.objects[0]!
+
+    const u: GFunctor<Obj, Mor, Obj, Mor> = {
+      source: G1,
+      target: H1,
+      onObj: () => fixedObj,
       onMor: (m) => m
     }
 
@@ -53,23 +58,31 @@ describe('Groupoid Kan with automorphism quotient (FinSet)', () => {
     const X: FinSetObj = { elements: ['a', 'b'] }
     const swap: FinSetMor = { from: X, to: X, map: [1, 0] }
 
-    const IfinH = { carrier: ['h'] as const }
+    const IfinH = IndexedFamilies.finiteIndex(H1.objects)
 
     // Test fallback behavior (no coequalizer provided in this call)
-    const LanSimple = lanGroupoidFull(H1 as any, G1 as any, u,
-      { onObj: (_g) => X }, // no onMor
-      IfinH as any,
+    const LanSimple = lanGroupoidFull(
+      FinSet,
+      H1,
+      G1,
+      u,
+      { onObj: () => X }, // no onMor
+      IfinH,
       FinSet // has coequalizer but we don't provide F.onMor
     )
-    
+
     // Should fall back to iso-class version
     expect(LanSimple.at('h').elements.length).toBe(2) // no quotient, just the object
 
     // Test with full quotient (would need more complex implementation)
     // For now, just verify the structure exists
-    const LanFull = lanGroupoidFull(H1 as any, G1 as any, u,
-      { onObj: (_g) => X, onMor: (_phi) => swap },
-      IfinH as any,
+    const LanFull = lanGroupoidFull(
+      FinSet,
+      H1,
+      G1,
+      u,
+      { onObj: () => X, onMor: () => swap },
+      IfinH,
       FinSet
     )
     

--- a/test/two-cat.traversable-laws.spec.ts
+++ b/test/two-cat.traversable-laws.spec.ts
@@ -107,7 +107,7 @@ describe('Traversable laws', () => {
     
     // Register base traversables
     const OptionF: EndofunctorK1<'Option'> = { map: mapO }
-    const ResultF = ResultK1<string>()
+    const ResultF = ResultK1<string>() as EndofunctorK1<['Either', 'string']>
     R.register(OptionF, TraversableOptionK1)
     R.register(ResultF, TraversableEitherK1<string>())
     
@@ -126,12 +126,12 @@ describe('Traversable laws', () => {
     expect(TCompM).toBeDefined()
     
     // Test that they work with Promise distribution
-    const sumVal = inL<'Option', ['Result', 'string'], number>(Some(Promise.resolve(42)))
+    const sumVal = inL<'Option', ['Either', 'string'], Promise<number>>(Some(Promise.resolve(42)))
     const sumSeq = distributePromiseK1(TSumM!)
     const sumResult = await sumSeq.app(sumVal)
-    expect(eq(sumResult, inL<'Option', ['Result', 'string'], number>(Some(42)))).toBe(true)
-    
-    const prodVal = prod<'Option', ['Result', 'string'], number>(Some(Promise.resolve(10)), Ok(Promise.resolve(20)))
+    expect(eq(sumResult, inL<'Option', ['Either', 'string'], number>(Some(42)))).toBe(true)
+
+    const prodVal = prod<'Option', ['Either', 'string'], Promise<number>>(Some(Promise.resolve(10)), Ok(Promise.resolve(20)))
     const prodSeq = distributePromiseK1(TProdM!)
     const prodResult = await prodSeq.app(prodVal)
     expect(eq(prodResult.left, Some(10))).toBe(true)

--- a/test/virtual-equipment/adapters.spec.ts
+++ b/test/virtual-equipment/adapters.spec.ts
@@ -1,5 +1,5 @@
-import type { Functor } from "../../functor";
 import { describe, expect, test } from "vitest";
+import type { Functor } from "../../functor";
 import {
   RelTightCategory,
   horizontalComposeProarrows,
@@ -16,6 +16,7 @@ import {
 import { TwoObjectCategory, nonIdentity } from "../../two-object-cat";
 import type { TwoArrow, TwoObject } from "../../two-object-cat";
 import { OrdObj } from "../../finord";
+import type { Ord } from "../../finord";
 import { SetCat } from "../../set-cat";
 
 const constantStarFunctor: Functor<TwoObject, TwoArrow, TwoObject, TwoArrow> = {
@@ -29,8 +30,8 @@ describe("virtual equipment adapters", () => {
       TwoObjectCategory,
       TwoObjectCategory,
       {
-        F0: (obj) => obj,
-        F1: (arrow) => arrow,
+        F0: (obj: TwoObject) => obj,
+        F1: (arrow: TwoArrow) => arrow,
       },
       {
         objects: TwoObjectCategory.objects,
@@ -97,8 +98,9 @@ describe("virtual equipment adapters", () => {
     const cod = SetCat.obj(["L", "R"] as const);
     const img = SetCat.obj(["L", "R"] as const);
 
-    const f = SetCat.hom(dom, cod, (value) => (value === ord2 ? "L" : "R"));
-    const g = SetCat.hom(cod, img, (value) => value);
+    type LR = "L" | "R";
+    const f = SetCat.hom(dom, cod, (value: Ord) => (value === ord2 ? "L" : "R"));
+    const g = SetCat.hom(cod, img, (value: LR) => value);
 
     const equipment = makeSetEquipment([dom, cod, img]);
     expect(equipment.objects).toEqual([dom, cod, img]);

--- a/test/virtual-equipment/tight-primitives.spec.ts
+++ b/test/virtual-equipment/tight-primitives.spec.ts
@@ -37,11 +37,13 @@ import {
 import { TwoObjectCategory, nonIdentity } from "../../two-object-cat";
 import type { TwoArrow, TwoObject } from "../../two-object-cat";
 
+type CanonicalEntry = (typeof canonicalTightCategories)[number];
+
 describe("virtual equipment tight primitive catalogue", () => {
   test("functors can be promoted and demoted without losing data", () => {
     const identityFunctor: Functor<TwoObject, TwoArrow, TwoObject, TwoArrow> = {
-      F0: (obj) => obj,
-      F1: (arrow) => arrow,
+      F0: (obj: TwoObject) => obj,
+      F1: (arrow: TwoArrow) => arrow,
     };
 
     const { functor: catFunctor, report } = promoteFunctor(
@@ -67,7 +69,11 @@ describe("virtual equipment tight primitive catalogue", () => {
   });
 
   test("catalogued categories expose explicit endpoints", () => {
-    expect(canonicalTightCategories.some((entry) => entry.name === "TwoObjectCategory")).toBe(true);
+    expect(
+      canonicalTightCategories.some(
+        (entry: CanonicalEntry) => entry.name === "TwoObjectCategory",
+      ),
+    ).toBe(true);
     for (const entry of canonicalTightCategories) {
       expect(finiteCategoryHasExplicitEndpoints(entry.category)).toBe(true);
     }
@@ -97,8 +103,8 @@ describe("virtual equipment tight primitive catalogue", () => {
       TwoObjectCategory,
       TwoObjectCategory,
       {
-        F0: (obj) => obj,
-        F1: (arrow) => arrow,
+        F0: (obj: TwoObject) => obj,
+        F1: (arrow: TwoArrow) => arrow,
       },
       samples,
     );
@@ -128,12 +134,12 @@ describe("virtual equipment tight primitive catalogue", () => {
     const tightLayer = defaultTightLayer(
       TwoObjectCategory,
       idFunctor,
-      (g, f) => composeFun(g, f),
+      (g: TwoArrow, f: TwoArrow) => composeFun(g, f),
     );
     const equipment = virtualiseTightCategory(
       tightLayer,
       TwoObjectCategory.objects,
-      (left, right) => left === right,
+      (left: TwoObject, right: TwoObject) => left === right,
     );
 
     const idDot = identityProarrow(equipment, "•");
@@ -324,8 +330,8 @@ describe("virtual equipment tight primitive catalogue", () => {
       TwoObjectCategory,
       TwoObjectCategory,
       {
-        F0: (object) => object,
-        F1: (arrow) => arrow,
+        F0: (object: TwoObject) => object,
+        F1: (arrow: TwoArrow) => arrow,
       },
       samples,
     );
@@ -333,13 +339,13 @@ describe("virtual equipment tight primitive catalogue", () => {
     const tightLayer = defaultTightLayer(
       TwoObjectCategory,
       idFunctor,
-      (g, f) => composeFun(g, f),
+      (g: TwoArrow, f: TwoArrow) => composeFun(g, f),
     );
 
     const equipment = virtualiseTightCategory(
       tightLayer,
       TwoObjectCategory.objects,
-      (left, right) => left === right,
+      (left: TwoObject, right: TwoObject) => left === right,
     );
 
     const looseCell = identityProarrow(equipment, "•");
@@ -395,7 +401,11 @@ describe("virtual equipment tight primitive catalogue", () => {
     });
 
     expect(failingAnalysis.holds).toBe(false);
-    expect(failingAnalysis.issues.some((issue) => issue.includes("Unit right boundary"))).toBe(true);
+    expect(
+      failingAnalysis.issues.some((issue: string) =>
+        issue.includes("Unit right boundary"),
+      ),
+    ).toBe(true);
   });
 
   test("representable right loose adjoint certifies the left loose map", () => {
@@ -410,8 +420,8 @@ describe("virtual equipment tight primitive catalogue", () => {
       TwoObjectCategory,
       TwoObjectCategory,
       {
-        F0: (object) => object,
-        F1: (arrow) => arrow,
+        F0: (object: TwoObject) => object,
+        F1: (arrow: TwoArrow) => arrow,
       },
       samples,
     );
@@ -419,13 +429,13 @@ describe("virtual equipment tight primitive catalogue", () => {
     const tightLayer = defaultTightLayer(
       TwoObjectCategory,
       idFunctor,
-      (g, f) => composeFun(g, f),
+      (g: TwoArrow, f: TwoArrow) => composeFun(g, f),
     );
 
     const equipment = virtualiseTightCategory(
       tightLayer,
       TwoObjectCategory.objects,
-      (left, right) => left === right,
+      (left: TwoObject, right: TwoObject) => left === right,
     );
 
     const left = identityProarrow(equipment, "•");
@@ -494,8 +504,8 @@ describe("virtual equipment tight primitive catalogue", () => {
       TwoObjectCategory,
       TwoObjectCategory,
       {
-        F0: (object) => object,
-        F1: (arrow) => arrow,
+        F0: (object: TwoObject) => object,
+        F1: (arrow: TwoArrow) => arrow,
       },
       samples,
     );
@@ -503,13 +513,13 @@ describe("virtual equipment tight primitive catalogue", () => {
     const tightLayer = defaultTightLayer(
       TwoObjectCategory,
       idFunctor,
-      (g, f) => composeFun(g, f),
+      (g: TwoArrow, f: TwoArrow) => composeFun(g, f),
     );
 
     const equipment = virtualiseTightCategory(
       tightLayer,
       TwoObjectCategory.objects,
-      (left, right) => left === right,
+      (left: TwoObject, right: TwoObject) => left === right,
     );
 
     const loose = identityProarrow(equipment, "•");

--- a/test/vitest.d.ts
+++ b/test/vitest.d.ts
@@ -1,0 +1,55 @@
+declare module 'vitest' {
+  type TestImplementation = (...args: readonly unknown[]) => void | Promise<void>;
+
+  interface ChainableSuite {
+    (name: string, fn: TestImplementation): void;
+    skip: ChainableSuite;
+    only: ChainableSuite;
+    todo: (name: string) => void;
+    each: <T extends ReadonlyArray<readonly unknown[]>>(
+      cases: T
+    ) => (name: string, fn: (...args: T[number]) => void | Promise<void>) => void;
+  }
+
+  interface ChainableTest {
+    (name: string, fn: TestImplementation): void;
+    skip: ChainableTest;
+    only: ChainableTest;
+    todo: (name: string) => void;
+    concurrent: ChainableTest;
+    each: <T extends ReadonlyArray<readonly unknown[]>>(
+      cases: T
+    ) => (name: string, fn: (...args: T[number]) => void | Promise<void>) => void;
+  }
+
+  type MatcherResult = void | Promise<void>;
+  type MatcherImplementation = (...args: readonly unknown[]) => MatcherResult;
+
+  interface MatcherTree {
+    readonly not: MatcherTree;
+    readonly resolves: MatcherTree;
+    readonly rejects: MatcherTree;
+    toBe: MatcherImplementation;
+    toEqual: MatcherImplementation;
+    toBeDefined: MatcherImplementation;
+    toBeUndefined: MatcherImplementation;
+    toBeNull: MatcherImplementation;
+    toBeTruthy: MatcherImplementation;
+    toBeInstanceOf: MatcherImplementation;
+    toContain: MatcherImplementation;
+    toContainEqual: MatcherImplementation;
+    toThrow: MatcherImplementation;
+    toMatch: MatcherImplementation;
+    toBeGreaterThan: MatcherImplementation;
+    toBeGreaterThanOrEqual: MatcherImplementation;
+    toBeLessThan: MatcherImplementation;
+    toBeLessThanOrEqual: MatcherImplementation;
+    toBeCloseTo: MatcherImplementation;
+    toHaveLength: MatcherImplementation;
+  }
+
+  export const describe: ChainableSuite;
+  export const test: ChainableTest;
+  export const it: ChainableTest;
+  export function expect(actual: unknown): MatcherTree;
+}


### PR DESCRIPTION
## Summary
- refine the traversable law registry test to reuse the concrete Either endofunctor metadata and pass Promise-wrapped values through Sum and Prod helpers with correct type arguments
- add a local `vitest` declaration file so describe/test/expect are typed even when the dependency is unavailable in the typecheck environment

## Testing
- npm run typecheck *(fails: missing local dependencies such as `fast-check` and numerous pre-existing sample/type-only import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fbf8afac83268213879a67a9bd0a